### PR TITLE
Implement ViT and DeiT for masked image modeling

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -168,12 +168,12 @@ defmodule Bumblebee do
     # ViT
     "ViTModel" => {Bumblebee.Vision.Vit, :base},
     "ViTForImageClassification" => {Bumblebee.Vision.Vit, :for_image_classification},
-    # "ViTForMaskedImageModeling" => {Bumblebee.Vision.Vit, :for_masked_image_modeling}
+    "ViTForMaskedImageModeling" => {Bumblebee.Vision.Vit, :for_masked_image_modeling},
     "DeiTModel" => {Bumblebee.Vision.Deit, :base},
     "DeiTForImageClassification" => {Bumblebee.Vision.Deit, :for_image_classification},
     "DeiTForImageClassificationWithTeacher" =>
       {Bumblebee.Vision.Deit, :for_image_classification_with_teacher},
-    # "DeiTForMaskedImageModeling" => {Bumblebee.Vision.Deit, :for_masked_image_modeling}
+    "DeiTForMaskedImageModeling" => {Bumblebee.Vision.Deit, :for_masked_image_modeling},
     # Bart
     "BartModel" => {Bumblebee.Text.Bart, :base},
     "BartForCausalLM" => {Bumblebee.Text.Bart, :for_causal_language_modeling},

--- a/lib/bumblebee/vision/vit.ex
+++ b/lib/bumblebee/vision/vit.ex
@@ -57,10 +57,10 @@ defmodule Bumblebee.Vision.Vit do
     * `:num_channels` - number of input channels. Defaults to `3`
 
     * `:qkv_bias` - whether to use bias in query, key, and value
-      projections
+      projections. Defaults to `true`
 
     * `:encoder_stride` - factor to increase the spatial resolution by
-    in the decoder head for masked image modeling
+      in the decoder head for masked image modeling. Defaults to `16`
 
   ### Common Options
 
@@ -134,9 +134,40 @@ defmodule Bumblebee.Vision.Vit do
     )
   end
 
-  # TODO: This requires a PixelShuffle implementation in Axon
-  # def model(%__MODULE__{architecture: :for_masked_image_modeling} = config) do
-  # end
+  def model(%__MODULE__{architecture: :for_masked_image_modeling} = config) do
+    outputs =
+      config
+      |> inputs()
+      |> vit(config, name: "vit")
+
+    logits =
+      outputs.last_hidden_state
+      |> Axon.nx(fn x ->
+        x = x[[0..-1//1, 1..-1//1]]
+
+        {batch_size, sequence_length, channels} = Nx.shape(x)
+        height = width = sequence_length |> :math.sqrt() |> floor()
+
+        x
+        |> Nx.transpose(axes: [0, 2, 1])
+        |> Nx.reshape({batch_size, channels, height, width})
+      end)
+      |> Axon.conv(config.encoder_stride ** 2 * 3,
+        kernel_size: 1,
+        kernel_initializer: kernel_initializer(config),
+        name: join("decoder", 0)
+      )
+      |> Layers.pixel_shuffle_layer(config.encoder_stride, name: join("decoder", 1))
+
+    Bumblebee.Utils.Model.output(
+      %{
+        logits: logits,
+        hidden_states: outputs.hidden_states,
+        attentions: outputs.attentions
+      },
+      config
+    )
+  end
 
   def model(%__MODULE__{architecture: :base} = config) do
     config


### PR DESCRIPTION
Closes #17.

There is no pre-trained version on HF, so I couldn't produce any practical example, but the model itself matches hf/transformers.