### PR TITLE
Rename individual layer output from hidden_states to hidden_state

### DIFF
--- a/lib/bumblebee/text/albert.ex
+++ b/lib/bumblebee/text/albert.ex
@@ -321,10 +321,10 @@ defmodule Bumblebee.Text.Albert do
   defp albert(inputs, config, opts) do
     name = opts[:name]
 
-    hidden_states = embeddings(inputs, config, name: join(name, "embeddings"))
+    hidden_state = embeddings(inputs, config, name: join(name, "embeddings"))
 
     {last_hidden_state, hidden_states, attentions} =
-      encoder(inputs, hidden_states, config, name: join(name, "encoder"))
+      encoder(inputs, hidden_state, config, name: join(name, "encoder"))
 
     pooler_output = pooler(last_hidden_state, config, name: join(name, "pooler"))
 
@@ -370,26 +370,26 @@ defmodule Bumblebee.Text.Albert do
     |> Axon.dropout(rate: config.hidden_dropout_prob, name: name <> ".dropout")
   end
 
-  defp encoder(inputs, hidden_states, config, opts) do
+  defp encoder(inputs, hidden_state, config, opts) do
     name = opts[:name]
 
-    hidden_states =
-      Axon.dense(hidden_states, config.hidden_size,
+    hidden_state =
+      Axon.dense(hidden_state, config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: join(name, "embedding_hidden_mapping_in")
       )
 
-    albert_layer_groups(inputs, hidden_states, config, name: join(name, "albert_layer_groups"))
+    albert_layer_groups(inputs, hidden_state, config, name: join(name, "albert_layer_groups"))
   end
 
-  defp albert_layer_groups(inputs, hidden_states, config, opts) do
+  defp albert_layer_groups(inputs, hidden_state, config, opts) do
     name = opts[:name]
 
-    last_hidden_state = hidden_states
-    all_hidden_states = {last_hidden_state}
-    all_attentions = {}
+    last_hidden_state = hidden_state
+    hidden_states = {hidden_state}
+    attentions = {}
 
-    initial_state = {last_hidden_state, all_hidden_states, all_attentions}
+    initial_state = {last_hidden_state, hidden_states, attentions}
 
     for idx <- 0..(config.num_hidden_layers - 1), reduce: initial_state do
       {last, states, attentions} ->
@@ -401,10 +401,10 @@ defmodule Bumblebee.Text.Albert do
     end
   end
 
-  defp albert_layers(inputs, hidden_states, all_hidden_states, all_attentions, config, opts) do
+  defp albert_layers(inputs, hidden_state, hidden_states, attentions, config, opts) do
     name = opts[:name]
 
-    initial_state = {hidden_states, all_hidden_states, all_attentions}
+    initial_state = {hidden_state, hidden_states, attentions}
 
     for idx <- 0..(config.inner_group_num - 1), reduce: initial_state do
       {last, states, attentions} ->
@@ -413,15 +413,13 @@ defmodule Bumblebee.Text.Albert do
     end
   end
 
-  defp albert_layer(inputs, hidden_states, config, opts) do
+  defp albert_layer(inputs, hidden_state, config, opts) do
     name = opts[:name]
 
     {attention_output, attention_weights} =
-      self_attention(hidden_states, inputs["attention_mask"], config,
-        name: join(name, "attention")
-      )
+      self_attention(hidden_state, inputs["attention_mask"], config, name: join(name, "attention"))
 
-    hidden_states =
+    hidden_state =
       attention_output
       |> Axon.dense(config.intermediate_size,
         kernel_initializer: kernel_initializer(config),
@@ -440,16 +438,16 @@ defmodule Bumblebee.Text.Albert do
         channel_index: 2
       )
 
-    {hidden_states, attention_weights}
+    {hidden_state, attention_weights}
   end
 
-  defp self_attention(hidden_states, attention_mask, config, opts) do
+  defp self_attention(hidden_state, attention_mask, config, opts) do
     name = opts[:name]
 
     head_dim = div(config.hidden_size, config.num_attention_heads)
 
     query_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: join(name, "query")
@@ -457,7 +455,7 @@ defmodule Bumblebee.Text.Albert do
       |> Axon.reshape({:auto, config.num_attention_heads, head_dim})
 
     value_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: join(name, "value")
@@ -465,7 +463,7 @@ defmodule Bumblebee.Text.Albert do
       |> Axon.reshape({:auto, config.num_attention_heads, head_dim})
 
     key_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: join(name, "key")
@@ -495,7 +493,7 @@ defmodule Bumblebee.Text.Albert do
         name: join(name, "dense")
       )
       |> Axon.dropout(rate: config.hidden_dropout_prob, name: join(name, "dense.dropout"))
-      |> Axon.add(hidden_states)
+      |> Axon.add(hidden_state)
       |> Axon.layer_norm(
         epsilon: config.layer_norm_eps,
         name: join(name, "LayerNorm"),
@@ -505,10 +503,10 @@ defmodule Bumblebee.Text.Albert do
     {projected, attention_weights}
   end
 
-  defp pooler(hidden_states, config, opts) do
+  defp pooler(hidden_state, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Layers.take_token_layer(axis: 1)
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),

--- a/lib/bumblebee/text/bert.ex
+++ b/lib/bumblebee/text/bert.ex
@@ -368,13 +368,13 @@ defmodule Bumblebee.Text.Bert do
   defp bert(inputs, config, opts \\ []) do
     name = opts[:name]
 
-    hidden_states =
+    hidden_state =
       embeddings(inputs["input_ids"], inputs["token_type_ids"], inputs["position_ids"], config,
         name: join(name, "embeddings")
       )
 
     {last_hidden_state, hidden_states, attentions} =
-      encoder(hidden_states, inputs["attention_mask"], inputs["head_mask"], config,
+      encoder(hidden_state, inputs["attention_mask"], inputs["head_mask"], config,
         name: join(name, "encoder")
       )
 
@@ -418,60 +418,60 @@ defmodule Bumblebee.Text.Bert do
     |> Axon.dropout(rate: config.hidden_dropout_prob, name: name <> ".dropout")
   end
 
-  defp encoder(hidden_states, attention_mask, head_mask, config, opts) do
+  defp encoder(hidden_state, attention_mask, head_mask, config, opts) do
     name = opts[:name]
 
-    encoder_layers(hidden_states, attention_mask, head_mask, config, name: join(name, "layer"))
+    encoder_layers(hidden_state, attention_mask, head_mask, config, name: join(name, "layer"))
   end
 
-  defp encoder_layers(hidden_states, attention_mask, head_mask, config, opts) do
+  defp encoder_layers(hidden_state, attention_mask, head_mask, config, opts) do
     name = opts[:name]
 
-    for idx <- 0..(config.num_hidden_layers - 1), reduce: {hidden_states, {hidden_states}, {}} do
-      {hidden_states, all_hidden_states, all_attention_outputs} ->
+    for idx <- 0..(config.num_hidden_layers - 1), reduce: {hidden_state, {hidden_state}, {}} do
+      {hidden_state, hidden_states, attentions} ->
         layer_head_mask = Axon.nx(head_mask, & &1[idx])
 
-        {hidden_states, attention_weights} =
-          bert_layer(hidden_states, attention_mask, layer_head_mask, config, name: join(name, idx))
+        {hidden_state, attention} =
+          bert_layer(hidden_state, attention_mask, layer_head_mask, config, name: join(name, idx))
 
         {
-          hidden_states,
-          Tuple.append(all_hidden_states, hidden_states),
-          Tuple.append(all_attention_outputs, attention_weights)
+          hidden_state,
+          Tuple.append(hidden_states, hidden_state),
+          Tuple.append(attentions, attention)
         }
     end
   end
 
-  defp bert_layer(hidden_states, attention_mask, layer_head_mask, config, opts) do
+  defp bert_layer(hidden_state, attention_mask, layer_head_mask, config, opts) do
     name = opts[:name]
 
-    {attention_outputs, attention_weights} =
-      attention(hidden_states, attention_mask, layer_head_mask, config, name: name <> ".attention")
+    {attention_output, attention} =
+      attention(hidden_state, attention_mask, layer_head_mask, config, name: name <> ".attention")
 
-    hidden_states = intermediate(attention_outputs, config, name: name <> ".intermediate")
-    hidden_states = output(hidden_states, attention_outputs, config, name: name <> ".output")
+    hidden_state = intermediate(attention_output, config, name: name <> ".intermediate")
+    hidden_state = output(hidden_state, attention_output, config, name: name <> ".output")
 
-    {hidden_states, attention_weights}
+    {hidden_state, attention}
   end
 
-  defp attention(hidden_states, attention_mask, layer_head_mask, config, opts) do
+  defp attention(hidden_state, attention_mask, layer_head_mask, config, opts) do
     name = opts[:name]
 
-    {attention_output, attention_weights} =
-      self_attention(hidden_states, attention_mask, layer_head_mask, config, name: name <> ".self")
+    {attention_output, attention} =
+      self_attention(hidden_state, attention_mask, layer_head_mask, config, name: name <> ".self")
 
-    hidden_states = self_output(attention_output, hidden_states, config, name: name <> ".output")
+    hidden_state = self_output(attention_output, hidden_state, config, name: name <> ".output")
 
-    {hidden_states, attention_weights}
+    {hidden_state, attention}
   end
 
-  defp self_attention(hidden_states, attention_mask, layer_head_mask, config, opts) do
+  defp self_attention(hidden_state, attention_mask, layer_head_mask, config, opts) do
     name = opts[:name]
 
     head_dim = div(config.hidden_size, config.num_attention_heads)
 
     query_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: name <> ".query"
@@ -479,7 +479,7 @@ defmodule Bumblebee.Text.Bert do
       |> Axon.reshape({:auto, config.num_attention_heads, head_dim})
 
     value_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: name <> ".value"
@@ -487,7 +487,7 @@ defmodule Bumblebee.Text.Bert do
       |> Axon.reshape({:auto, config.num_attention_heads, head_dim})
 
     key_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         name: name <> ".key"
@@ -516,10 +516,10 @@ defmodule Bumblebee.Text.Bert do
     {attention_output, attention_weights}
   end
 
-  defp self_output(hidden_states, input, config, opts) do
+  defp self_output(hidden_state, input, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),
       name: name <> ".dense"
@@ -533,10 +533,10 @@ defmodule Bumblebee.Text.Bert do
     )
   end
 
-  defp intermediate(hidden_states, config, opts) do
+  defp intermediate(hidden_state, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Axon.dense(config.intermediate_size,
       kernel_initializer: kernel_initializer(config),
       name: name <> ".dense"
@@ -544,10 +544,10 @@ defmodule Bumblebee.Text.Bert do
     |> Layers.activation_layer(config.hidden_act, name: name <> ".activation")
   end
 
-  defp output(hidden_states, attention_output, config, opts) do
+  defp output(hidden_state, attention_output, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),
       name: name <> ".dense"
@@ -561,10 +561,10 @@ defmodule Bumblebee.Text.Bert do
     )
   end
 
-  defp pooler(hidden_states, config, opts) do
+  defp pooler(hidden_state, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Layers.take_token_layer(index: 0, axis: 1, name: join(name, "head"))
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),

--- a/lib/bumblebee/vision/deit.ex
+++ b/lib/bumblebee/vision/deit.ex
@@ -209,13 +209,13 @@ defmodule Bumblebee.Vision.Deit do
   defp deit(inputs, config, opts \\ []) do
     name = opts[:name]
 
-    hidden_states = embeddings(inputs, config, name: join(name, "embeddings"))
+    hidden_state = embeddings(inputs, config, name: join(name, "embeddings"))
 
-    {hidden_states, all_hidden_states, all_attentions} =
-      encoder(hidden_states, config, name: join(name, "encoder"))
+    {hidden_state, hidden_states, attentions} =
+      encoder(hidden_state, config, name: join(name, "encoder"))
 
     last_hidden_state =
-      hidden_states
+      hidden_state
       |> Axon.layer_norm(
         channel_index: 2,
         epsilon: config.layer_norm_eps,
@@ -227,8 +227,8 @@ defmodule Bumblebee.Vision.Deit do
     %{
       last_hidden_state: last_hidden_state,
       pooler_output: pooled,
-      hidden_states: all_hidden_states,
-      attentions: all_attentions
+      hidden_states: hidden_states,
+      attentions: attentions
     }
   end
 
@@ -293,32 +293,37 @@ defmodule Bumblebee.Vision.Deit do
     )
   end
 
-  defp encoder(hidden_states, config, opts) do
+  defp encoder(hidden_state, config, opts) do
     name = opts[:name]
 
-    encoder_layers(hidden_states, config, name: join(name, "layer"))
+    encoder_layers(hidden_state, config, name: join(name, "layer"))
   end
 
-  defp encoder_layers(hidden_states, config, opts) do
+  defp encoder_layers(hidden_state, config, opts) do
     name = opts[:name]
 
-    last_hidden_state = hidden_states
-    all_hidden_states = {last_hidden_state}
-    all_attentions = {}
+    last_hidden_state = hidden_state
+    hidden_states = {hidden_state}
+    attentions = {}
 
     for idx <- 0..(config.num_hidden_layers - 1),
-        reduce: {last_hidden_state, all_hidden_states, all_attentions} do
-      {lhs, states, attns} ->
-        {next_state, next_attention} = encoder_layer(lhs, config, name: join(name, idx))
-        {next_state, Tuple.append(states, next_state), Tuple.append(attns, next_attention)}
+        reduce: {last_hidden_state, hidden_states, attentions} do
+      {hidden_state, hidden_states, attentions} ->
+        {hidden_state, attention} = encoder_layer(hidden_state, config, name: join(name, idx))
+
+        {
+          hidden_state,
+          Tuple.append(hidden_states, hidden_state),
+          Tuple.append(attentions, attention)
+        }
     end
   end
 
-  defp encoder_layer(hidden_states, config, opts) do
+  defp encoder_layer(hidden_state, config, opts) do
     name = opts[:name]
 
-    {attention_output, attention_weights} =
-      hidden_states
+    {attention_output, attention} =
+      hidden_state
       |> Axon.layer_norm(
         channel_index: 2,
         epsilon: config.layer_norm_eps,
@@ -326,7 +331,7 @@ defmodule Bumblebee.Vision.Deit do
       )
       |> attention(config, name: join(name, "attention"))
 
-    attention_output = Axon.add(attention_output, hidden_states)
+    attention_output = Axon.add(attention_output, hidden_state)
 
     layer_output =
       attention_output
@@ -338,28 +343,28 @@ defmodule Bumblebee.Vision.Deit do
       |> intermediate(config, name: join(name, "intermediate"))
       |> output(attention_output, config, name: join(name, "output"))
 
-    {layer_output, attention_weights}
+    {layer_output, attention}
   end
 
-  defp attention(hidden_states, config, opts) do
+  defp attention(hidden_state, config, opts) do
     name = opts[:name]
 
-    {attention_output, attention_weights} =
-      self_attention(hidden_states, config, name: join(name, "attention"))
+    {attention_output, attention} =
+      self_attention(hidden_state, config, name: join(name, "attention"))
 
     attention_output =
-      self_output(attention_output, hidden_states, config, name: join(name, "output"))
+      self_output(attention_output, hidden_state, config, name: join(name, "output"))
 
-    {attention_output, attention_weights}
+    {attention_output, attention}
   end
 
-  defp self_attention(hidden_states, config, opts) do
+  defp self_attention(hidden_state, config, opts) do
     name = opts[:name]
 
     head_dim = div(config.hidden_size, config.num_attention_heads)
 
     query_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         use_bias: config.qkv_bias,
@@ -368,7 +373,7 @@ defmodule Bumblebee.Vision.Deit do
       |> Axon.reshape({:auto, config.num_attention_heads, head_dim})
 
     key_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         use_bias: config.qkv_bias,
@@ -377,7 +382,7 @@ defmodule Bumblebee.Vision.Deit do
       |> Axon.reshape({:auto, config.num_attention_heads, head_dim})
 
     value_states =
-      hidden_states
+      hidden_state
       |> Axon.dense(config.hidden_size,
         kernel_initializer: kernel_initializer(config),
         use_bias: config.qkv_bias,
@@ -404,10 +409,10 @@ defmodule Bumblebee.Vision.Deit do
     {attention_output, attention_weights}
   end
 
-  defp self_output(hidden_states, _input_tensor, config, opts) do
+  defp self_output(hidden_state, _input_tensor, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),
       name: join(name, "dense")
@@ -415,10 +420,10 @@ defmodule Bumblebee.Vision.Deit do
     |> Axon.dropout(rate: config.hidden_dropout_prob, name: join(name, "dropout"))
   end
 
-  defp intermediate(hidden_states, config, opts) do
+  defp intermediate(hidden_state, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Axon.dense(config.intermediate_size,
       kernel_initializer: kernel_initializer(config),
       name: join(name, "dense")
@@ -426,10 +431,10 @@ defmodule Bumblebee.Vision.Deit do
     |> Axon.activation(config.hidden_act)
   end
 
-  defp output(hidden_states, attention_output, config, opts) do
+  defp output(hidden_state, attention_output, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),
       name: join(name, "dense")
@@ -438,10 +443,10 @@ defmodule Bumblebee.Vision.Deit do
     |> Axon.add(attention_output, name: join(name, "residual"))
   end
 
-  defp pooler(hidden_states, config, opts) do
+  defp pooler(hidden_state, config, opts) do
     name = opts[:name]
 
-    hidden_states
+    hidden_state
     |> Layers.take_token_layer(index: 0, axis: 1, name: join(name, "head"))
     |> Axon.dense(config.hidden_size,
       kernel_initializer: kernel_initializer(config),


### PR DESCRIPTION
hf/transformers use the wording `hidden_states` for individual layer output, at the same time model outputs have optional `hidden_states` field, which is a list of all `hidden_states` from individual layers. This makes the implementation confusing at times, so after discussing with @seanmor5, we are renaming to a singular form.