### PR TITLE
Unify configuration under a single interface

### DIFF
--- a/lib/bumblebee/configurable.ex
+++ b/lib/bumblebee/configurable.ex
@@ -1,0 +1,15 @@
+defmodule Bumblebee.Configurable do
+  @moduledoc """
+  An interface for configurable entities.
+
+  A module implementing this behaviour is expected to define a struct
+  with configuration.
+  """
+
+  @type t :: struct()
+
+  @doc """
+  Configures the struct.
+  """
+  @callback config(t(), keyword()) :: t()
+end

--- a/lib/bumblebee/diffusion/ddim_scheduler.ex
+++ b/lib/bumblebee/diffusion/ddim_scheduler.ex
@@ -63,6 +63,7 @@ defmodule Bumblebee.Diffusion.DdimScheduler do
   alias Bumblebee.Diffusion.SchedulerUtils
 
   @behaviour Bumblebee.Scheduler
+  @behaviour Bumblebee.Configurable
 
   defstruct num_train_timesteps: 1000,
             beta_schedule: :linear,

--- a/lib/bumblebee/diffusion/pndm_scheduler.ex
+++ b/lib/bumblebee/diffusion/pndm_scheduler.ex
@@ -51,6 +51,7 @@ defmodule Bumblebee.Diffusion.PndmScheduler do
   alias Bumblebee.Diffusion.SchedulerUtils
 
   @behaviour Bumblebee.Scheduler
+  @behaviour Bumblebee.Configurable
 
   defstruct num_train_timesteps: 1000,
             beta_schedule: :linear,

--- a/lib/bumblebee/diffusion/unet_2d_conditional.ex
+++ b/lib/bumblebee/diffusion/unet_2d_conditional.ex
@@ -117,6 +117,7 @@ defmodule Bumblebee.Diffusion.UNet2DConditional do
             attention_head_dim: 8
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(), do: [:base]

--- a/lib/bumblebee/diffusion/vae_kl.ex
+++ b/lib/bumblebee/diffusion/vae_kl.ex
@@ -75,6 +75,7 @@ defmodule Bumblebee.Diffusion.VaeKl do
             act_fn: :silu
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(), do: [:base, :encoder, :decoder]

--- a/lib/bumblebee/featurizer.ex
+++ b/lib/bumblebee/featurizer.ex
@@ -8,18 +8,7 @@ defmodule Bumblebee.Featurizer do
   a configuration struct.
   """
 
-  @typedoc """
-  Featurizer configuration and metadata.
-  """
-  @type t :: %{
-          optional(atom()) => term(),
-          __struct__: atom()
-        }
-
-  @doc """
-  Configures the featurizer.
-  """
-  @callback config(t(), keyword()) :: t()
+  @type t :: Bumblebee.Configurable.t()
 
   @doc """
   Performs feature extraction on the given input.

--- a/lib/bumblebee/huggingface/transformers/config.ex
+++ b/lib/bumblebee/huggingface/transformers/config.ex
@@ -1,8 +1,8 @@
 defprotocol Bumblebee.HuggingFace.Transformers.Config do
-  @moduledoc """
-  This protocol defines a bridge between bumblebee and huggingface/transformers
-  configuration.
-  """
+  @moduledoc false
+
+  # This protocol defines a bridge between Bumblebee and huggingface/transformers
+  # configuration.
 
   @doc """
   Updates configuration based on a parsed JSON data.

--- a/lib/bumblebee/model_spec.ex
+++ b/lib/bumblebee/model_spec.ex
@@ -7,14 +7,7 @@ defmodule Bumblebee.ModelSpec do
   a configuration struct.
   """
 
-  @typedoc """
-  Model configuration and metadata.
-  """
-  @type t :: %{
-          optional(atom()) => term(),
-          __struct__: atom(),
-          architecture: atom()
-        }
+  @type t :: Bumblebee.Configurable.t()
 
   @doc """
   Returns the list of supported model architectures.
@@ -30,11 +23,6 @@ defmodule Bumblebee.ModelSpec do
   to determine layer name mapping.
   """
   @callback base_model_prefix() :: String.t()
-
-  @doc """
-  Configures the model.
-  """
-  @callback config(t(), keyword()) :: t()
 
   @doc """
   Builds a template input for the model.

--- a/lib/bumblebee/scheduler.ex
+++ b/lib/bumblebee/scheduler.ex
@@ -36,20 +36,9 @@ defmodule Bumblebee.Scheduler do
   values $t$ (points in time).
   """
 
-  @typedoc """
-  Scheduler configuration and metadata.
-  """
-  @type t :: %{
-          optional(atom()) => term(),
-          __struct__: atom()
-        }
+  @type t :: Bumblebee.Configurable.t()
 
   @type state :: Nx.Container.t()
-
-  @doc """
-  Configures the scheduler.
-  """
-  @callback config(t(), keyword()) :: t()
 
   @doc """
   Initializes state for a new scheduler loop.

--- a/lib/bumblebee/text/albert.ex
+++ b/lib/bumblebee/text/albert.ex
@@ -149,6 +149,7 @@ defmodule Bumblebee.Text.Albert do
             ] ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def base_model_prefix(), do: "albert"

--- a/lib/bumblebee/text/bart.ex
+++ b/lib/bumblebee/text/bart.ex
@@ -202,6 +202,7 @@ defmodule Bumblebee.Text.Bart do
               Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
   @behaviour Bumblebee.Text.Generation
 
   @impl true

--- a/lib/bumblebee/text/bert.ex
+++ b/lib/bumblebee/text/bert.ex
@@ -159,6 +159,7 @@ defmodule Bumblebee.Text.Bert do
             ] ++ Shared.generation_defaults() ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
   @behaviour Bumblebee.Text.Generation
 
   @impl true

--- a/lib/bumblebee/text/clip_text.ex
+++ b/lib/bumblebee/text/clip_text.ex
@@ -89,6 +89,7 @@ defmodule Bumblebee.Text.ClipText do
             ] ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(), do: [:base]

--- a/lib/bumblebee/text/gpt2.ex
+++ b/lib/bumblebee/text/gpt2.ex
@@ -158,6 +158,7 @@ defmodule Bumblebee.Text.Gpt2 do
             ] ++ Shared.generation_defaults() ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
   @behaviour Bumblebee.Text.Generation
 
   @impl true

--- a/lib/bumblebee/text/mbart.ex
+++ b/lib/bumblebee/text/mbart.ex
@@ -198,6 +198,7 @@ defmodule Bumblebee.Text.Mbart do
               Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
   @behaviour Bumblebee.Text.Generation
 
   @impl true

--- a/lib/bumblebee/text/roberta.ex
+++ b/lib/bumblebee/text/roberta.ex
@@ -156,6 +156,7 @@ defmodule Bumblebee.Text.Roberta do
             ] ++ Shared.generation_defaults() ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
   @behaviour Bumblebee.Text.Generation
 
   @impl true

--- a/lib/bumblebee/vision/convnext.ex
+++ b/lib/bumblebee/vision/convnext.ex
@@ -77,6 +77,7 @@ defmodule Bumblebee.Vision.ConvNext do
             ] ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(), do: [:base, :for_image_classification]

--- a/lib/bumblebee/vision/convnext_featurizer.ex
+++ b/lib/bumblebee/vision/convnext_featurizer.ex
@@ -36,6 +36,7 @@ defmodule Bumblebee.Vision.ConvNextFeaturizer do
   alias Bumblebee.Utils.Image
 
   @behaviour Bumblebee.Featurizer
+  @behaviour Bumblebee.Configurable
 
   defstruct do_resize: true,
             size: 224,

--- a/lib/bumblebee/vision/deit.ex
+++ b/lib/bumblebee/vision/deit.ex
@@ -104,6 +104,7 @@ defmodule Bumblebee.Vision.Deit do
             ] ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(),

--- a/lib/bumblebee/vision/deit_featurizer.ex
+++ b/lib/bumblebee/vision/deit_featurizer.ex
@@ -38,6 +38,7 @@ defmodule Bumblebee.Vision.DeitFeaturizer do
   alias Bumblebee.Utils.Image
 
   @behaviour Bumblebee.Featurizer
+  @behaviour Bumblebee.Configurable
 
   defstruct do_resize: true,
             size: 256,

--- a/lib/bumblebee/vision/resnet.ex
+++ b/lib/bumblebee/vision/resnet.ex
@@ -64,6 +64,7 @@ defmodule Bumblebee.Vision.ResNet do
             ] ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(), do: [:base, :for_image_classification]

--- a/lib/bumblebee/vision/vit.ex
+++ b/lib/bumblebee/vision/vit.ex
@@ -99,6 +99,7 @@ defmodule Bumblebee.Vision.Vit do
             ] ++ Shared.common_config_defaults(@common_keys)
 
   @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
 
   @impl true
   def architectures(), do: [:base, :for_image_classification, :for_masked_image_modeling]

--- a/lib/bumblebee/vision/vit_featurizer.ex
+++ b/lib/bumblebee/vision/vit_featurizer.ex
@@ -30,6 +30,7 @@ defmodule Bumblebee.Vision.VitFeaturizer do
   alias Bumblebee.Utils.Image
 
   @behaviour Bumblebee.Featurizer
+  @behaviour Bumblebee.Configurable
 
   defstruct do_resize: true,
             size: 224,

--- a/mix.exs
+++ b/mix.exs
@@ -86,12 +86,19 @@ defmodule Bumblebee.MixProject do
           Bumblebee.Diffusion.PndmScheduler
         ],
         Interfaces: [
+          Bumblebee.Configurable,
           Bumblebee.ModelSpec,
           Bumblebee.Featurizer,
           Bumblebee.Tokenizer,
-          Bumblebee.Scheduler,
-          Bumblebee.HuggingFace.Transformers.Config
+          Bumblebee.Scheduler
         ]
+      ],
+      groups_for_functions: [
+        # Bumblebee
+        Models: &(&1[:type] == :model),
+        Featurizers: &(&1[:type] == :featurizer),
+        Tokenizers: &(&1[:type] == :tokenizer),
+        Schedulers: &(&1[:type] == :scheduler)
       ],
       before_closing_body_tag: &before_closing_body_tag/1
     ]


### PR DESCRIPTION
I also want to rename the usage of model `config` to `spec`, otherwise it's weirdly ambiguous. We similarly say `featurizer` or `scheduler`, both of which are some configs. Will send a separate PR to keep this one small :)