### PR TITLE
Disable progress bar in test env

### DIFF
--- a/lib/bumblebee/utils.ex
+++ b/lib/bumblebee/utils.ex
@@ -1,0 +1,11 @@
+defmodule Bumblebee.Utils do
+  @moduledoc false
+
+  @doc """
+  Checks if the progress bar is enabled globally.
+  """
+  @spec progress_bar_enabled? :: boolean()
+  def progress_bar_enabled?() do
+    Application.get_env(:bumblebee, :progress_bar_enabled, true)
+  end
+end

--- a/lib/bumblebee/utils/http.ex
+++ b/lib/bumblebee/utils/http.ex
@@ -81,7 +81,8 @@ defmodule Bumblebee.Utils.HTTP do
         part_size = byte_size(body_part)
         state = update_in(state.size, &(&1 + part_size))
 
-        if state.total_size && part_size != state.total_size do
+        if Bumblebee.Utils.progress_bar_enabled?() &&
+             state.total_size && part_size != state.total_size do
           ProgressBar.render(state.size, state.total_size, suffix: :bytes)
         end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
 Nx.global_default_backend(EXLA.Backend)
 
+Application.put_env(:bumblebee, :progress_bar_enabled, false)
+
 ExUnit.start(exclude: [:slow])


### PR DESCRIPTION
In tests we download a bunch of models and the progress clobbers the log. This is particularly annoying on CI where each progress step is printed in a separate line and the log gets truncated.