### PR TITLE
Remove redundant :channel_index options

### DIFF
--- a/lib/bumblebee/diffusion/layers/unet.ex
+++ b/lib/bumblebee/diffusion/layers/unet.ex
@@ -328,7 +328,7 @@ defmodule Bumblebee.Diffusion.Layers.UNet do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(name: join(name, "norm1"), channel_index: 2)
+      |> Axon.layer_norm(name: join(name, "norm1"))
       |> attention(nil,
         hidden_size: opts[:hidden_size],
         num_heads: opts[:num_heads],
@@ -341,7 +341,7 @@ defmodule Bumblebee.Diffusion.Layers.UNet do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(name: join(name, "norm2"), channel_index: 2)
+      |> Axon.layer_norm(name: join(name, "norm2"))
       |> attention(cross_hidden_state,
         hidden_size: opts[:hidden_size],
         num_heads: opts[:num_heads],
@@ -353,7 +353,7 @@ defmodule Bumblebee.Diffusion.Layers.UNet do
     residual = hidden_state
 
     hidden_state
-    |> Axon.layer_norm(name: join(name, "norm3"), channel_index: 2)
+    |> Axon.layer_norm(name: join(name, "norm3"))
     |> feed_forward_geglu(opts[:hidden_size], dropout: opts[:dropout], name: join(name, "ff"))
     |> Axon.add(residual)
   end

--- a/lib/bumblebee/layers/clip.ex
+++ b/lib/bumblebee/layers/clip.ex
@@ -53,11 +53,7 @@ defmodule Bumblebee.Layers.Clip do
 
     {hidden_state, attention_weights} =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layer_norm1")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layer_norm1"))
       |> attention(attention_mask, spec, name: join(name, "self_attn"), causal?: causal?)
 
     hidden_state = Axon.add(residual, hidden_state)
@@ -66,11 +62,7 @@ defmodule Bumblebee.Layers.Clip do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layer_norm2")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layer_norm2"))
       |> mlp(spec, name: join(name, "mlp"))
       |> Axon.add(residual)
 

--- a/lib/bumblebee/text/albert.ex
+++ b/lib/bumblebee/text/albert.ex
@@ -376,11 +376,7 @@ defmodule Bumblebee.Text.Albert do
       )
 
     Axon.add([inputs_embeddings, position_embeddings, token_type_embeddings])
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
   end
 
@@ -451,8 +447,7 @@ defmodule Bumblebee.Text.Albert do
       |> Axon.add(attention_output, name: join(name, "ffn.residual"))
       |> Axon.layer_norm(
         epsilon: spec.layer_norm_epsilon,
-        name: join(name, "full_layer_layer_norm"),
-        channel_index: 2
+        name: join(name, "full_layer_layer_norm")
       )
 
     {hidden_state, attention_weights}
@@ -507,11 +502,7 @@ defmodule Bumblebee.Text.Albert do
       )
       |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dense.dropout"))
       |> Axon.add(hidden_state)
-      |> Axon.layer_norm(
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "LayerNorm"),
-        channel_index: 2
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
 
     {projected, attention_weights}
   end
@@ -552,11 +543,7 @@ defmodule Bumblebee.Text.Albert do
       name: join(name, "dense")
     )
     |> Layers.activation(spec.activation, name: join(name, "activation"))
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
   end
 
   defp classifier_dropout_rate(spec) do

--- a/lib/bumblebee/text/bart.ex
+++ b/lib/bumblebee/text/bart.ex
@@ -534,7 +534,7 @@ defmodule Bumblebee.Text.Bart do
 
     input_embeddings
     |> Axon.add(position_embeddings)
-    |> Axon.layer_norm(channel_index: 2, epsilon: 1.0e-5, name: join(name, "layernorm_embedding"))
+    |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "layernorm_embedding"))
     |> Axon.dropout(rate: spec.dropout_rate)
     |> encoder_blocks(attention_mask, attention_head_mask, spec, name: join(name, "layers"))
   end
@@ -618,11 +618,7 @@ defmodule Bumblebee.Text.Bart do
       hidden_state
       |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout.0"))
       |> Axon.add(residual, name: join(name, "residual.0"))
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "self_attn_layer_norm")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "self_attn_layer_norm"))
 
     residual = hidden_state
 
@@ -639,7 +635,7 @@ defmodule Bumblebee.Text.Bart do
         name: join(name, "fc2")
       )
       |> Axon.add(residual, name: join(name, "residual.1"))
-      |> Axon.layer_norm(channel_index: 2, epsilon: 1.0e-5, name: join(name, "final_layer_norm"))
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "final_layer_norm"))
 
     {hidden_state, attention}
   end
@@ -665,11 +661,7 @@ defmodule Bumblebee.Text.Bart do
     outputs =
       input_embeddings
       |> Axon.add(position_embeddings)
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "layernorm_embedding")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "layernorm_embedding"))
       |> Axon.dropout(rate: spec.dropout_rate)
       |> decoder_blocks(
         attention_mask,
@@ -780,11 +772,7 @@ defmodule Bumblebee.Text.Bart do
       hidden_state
       |> Axon.dropout(rate: spec.dropout_rate)
       |> Axon.add(residual)
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "self_attn_layer_norm")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "self_attn_layer_norm"))
 
     {hidden_state, cross_attention, cross_attention_cache} =
       Layers.if_present encoder_hidden_state do
@@ -807,11 +795,7 @@ defmodule Bumblebee.Text.Bart do
           hidden_state
           |> Axon.dropout(rate: spec.dropout_rate)
           |> Axon.add(residual)
-          |> Axon.layer_norm(
-            channel_index: 2,
-            epsilon: 1.0e-5,
-            name: join(name, "encoder_attn_layer_norm")
-          )
+          |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "encoder_attn_layer_norm"))
 
         {hidden_state, cross_attention, cross_attention_cache}
       else
@@ -828,7 +812,7 @@ defmodule Bumblebee.Text.Bart do
       |> Axon.dense(spec.hidden_size, name: join(name, "fc2"))
       |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout.2"))
       |> Axon.add(residual)
-      |> Axon.layer_norm(channel_index: 2, epsilon: 1.0e-5, name: join(name, "final_layer_norm"))
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "final_layer_norm"))
 
     block_cache =
       Layers.Decoder.put_attention_caches(

--- a/lib/bumblebee/text/bert.ex
+++ b/lib/bumblebee/text/bert.ex
@@ -493,11 +493,7 @@ defmodule Bumblebee.Text.Bert do
       )
 
     Axon.add([inputs_embeddings, position_embeddings, token_type_embeddings])
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
   end
 
@@ -769,11 +765,7 @@ defmodule Bumblebee.Text.Bert do
     )
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
     |> Axon.add(input)
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
   end
 
   defp intermediate(hidden_state, spec, opts) do
@@ -797,11 +789,7 @@ defmodule Bumblebee.Text.Bert do
     )
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
     |> Axon.add(attention_output)
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
   end
 
   defp pooler(hidden_state, spec, opts) do
@@ -841,11 +829,7 @@ defmodule Bumblebee.Text.Bert do
       name: join(name, "dense")
     )
     |> Layers.activation(spec.activation, name: join(name, "activation"))
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
   end
 
   defp classifier_dropout_rate(spec) do

--- a/lib/bumblebee/text/clip_text.ex
+++ b/lib/bumblebee/text/clip_text.ex
@@ -163,7 +163,6 @@ defmodule Bumblebee.Text.ClipText do
 
     hidden_state =
       Axon.layer_norm(encoder_outputs.hidden_state,
-        channel_index: 2,
         epsilon: spec.layer_norm_epsilon,
         name: join(name, "final_layer_norm")
       )

--- a/lib/bumblebee/text/gpt2.ex
+++ b/lib/bumblebee/text/gpt2.ex
@@ -344,7 +344,6 @@ defmodule Bumblebee.Text.Gpt2 do
 
     hidden_state =
       Axon.layer_norm(block_outputs.hidden_state,
-        channel_index: 2,
         epsilon: spec.layer_norm_epsilon,
         name: join(name, "ln_f")
       )
@@ -443,11 +442,7 @@ defmodule Bumblebee.Text.Gpt2 do
 
     {attention_output, attention_weights, self_attention_cache} =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "ln_1")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "ln_1"))
       |> attention(
         attention_mask,
         nil,
@@ -470,7 +465,6 @@ defmodule Bumblebee.Text.Gpt2 do
           {cross_attention_output, cross_attention_weights, cross_attention_cache} =
             hidden_state
             |> Axon.layer_norm(
-              channel_index: 2,
               epsilon: spec.layer_norm_epsilon,
               name: join(name, "ln_cross_attn")
             )
@@ -498,11 +492,7 @@ defmodule Bumblebee.Text.Gpt2 do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "ln_2")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "ln_2"))
       |> mlp(inner_dim, spec, name: join(name, "mlp"))
       |> Axon.add(residual)
 

--- a/lib/bumblebee/text/mbart.ex
+++ b/lib/bumblebee/text/mbart.ex
@@ -551,19 +551,11 @@ defmodule Bumblebee.Text.Mbart do
     encoder_outputs =
       input_embeddings
       |> Axon.add(position_embeddings)
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "layernorm_embedding")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "layernorm_embedding"))
       |> Axon.dropout(rate: spec.dropout_rate)
       |> encoder_blocks(attention_mask, attention_head_mask, spec, name: join(name, "layers"))
 
-    hidden_state =
-      Axon.layer_norm(encoder_outputs.hidden_state,
-        channel_index: 2,
-        name: join(name, "layer_norm")
-      )
+    hidden_state = Axon.layer_norm(encoder_outputs.hidden_state, name: join(name, "layer_norm"))
 
     %{
       hidden_state: hidden_state,
@@ -636,11 +628,7 @@ defmodule Bumblebee.Text.Mbart do
 
     {hidden_state, attention, _} =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "self_attn_layer_norm")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "self_attn_layer_norm"))
       |> attention(
         attention_mask,
         nil,
@@ -661,7 +649,7 @@ defmodule Bumblebee.Text.Mbart do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(channel_index: 2, name: join(name, "final_layer_norm"))
+      |> Axon.layer_norm(name: join(name, "final_layer_norm"))
       |> Axon.dense(spec.encoder_intermediate_size,
         kernel_initializer: kernel_initializer(spec),
         name: join(name, "fc1")
@@ -699,11 +687,7 @@ defmodule Bumblebee.Text.Mbart do
     decoder_outputs =
       input_embeddings
       |> Axon.add(position_embeddings)
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "layernorm_embedding")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "layernorm_embedding"))
       |> Axon.dropout(rate: spec.dropout_rate)
       |> decoder_blocks(
         attention_mask,
@@ -718,7 +702,7 @@ defmodule Bumblebee.Text.Mbart do
 
     hidden_state =
       decoder_outputs.hidden_state
-      |> Axon.layer_norm(channel_index: 2, name: join(name, "layer_norm"))
+      |> Axon.layer_norm(name: join(name, "layer_norm"))
 
     %{
       cache: Layers.Decoder.update_cache_offset(decoder_outputs.cache, input_embeddings),
@@ -808,11 +792,7 @@ defmodule Bumblebee.Text.Mbart do
 
     {hidden_state, self_attention, self_attention_cache} =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: 1.0e-5,
-        name: join(name, "self_attn_layer_norm")
-      )
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "self_attn_layer_norm"))
       |> attention(
         attention_mask,
         nil,
@@ -836,11 +816,7 @@ defmodule Bumblebee.Text.Mbart do
 
         {hidden_state, cross_attention, cross_attention_cache} =
           hidden_state
-          |> Axon.layer_norm(
-            channel_index: 2,
-            epsilon: 1.0e-5,
-            name: join(name, "encoder_attn_layer_norm")
-          )
+          |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "encoder_attn_layer_norm"))
           |> attention(
             encoder_attention_mask,
             encoder_hidden_state,
@@ -866,7 +842,7 @@ defmodule Bumblebee.Text.Mbart do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(channel_index: 2, epsilon: 1.0e-5, name: join(name, "final_layer_norm"))
+      |> Axon.layer_norm(epsilon: 1.0e-5, name: join(name, "final_layer_norm"))
       |> Axon.dense(spec.decoder_intermediate_size, name: join(name, "fc1"))
       |> Axon.activation(spec.activation, name: join(name, "activation"))
       |> Axon.dropout(rate: spec.activation_dropout_rate, name: join(name, "dropout.1"))

--- a/lib/bumblebee/text/roberta.ex
+++ b/lib/bumblebee/text/roberta.ex
@@ -453,11 +453,7 @@ defmodule Bumblebee.Text.Roberta do
       )
 
     Axon.add([inputs_embeddings, position_embeddings, token_type_embeddings])
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
   end
 
@@ -729,11 +725,7 @@ defmodule Bumblebee.Text.Roberta do
     )
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
     |> Axon.add(input)
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
   end
 
   defp intermediate(hidden_state, spec, opts) do
@@ -757,11 +749,7 @@ defmodule Bumblebee.Text.Roberta do
     )
     |> Axon.dropout(rate: spec.dropout_rate, name: join(name, "dropout"))
     |> Axon.add(attention_output)
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "LayerNorm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "LayerNorm"))
   end
 
   defp pooler(hidden_state, spec, opts) do
@@ -801,11 +789,7 @@ defmodule Bumblebee.Text.Roberta do
       name: join(name, "dense")
     )
     |> Layers.activation(spec.activation, name: join(name, "activation"))
-    |> Axon.layer_norm(
-      epsilon: spec.layer_norm_epsilon,
-      name: join(name, "layer_norm"),
-      channel_index: 2
-    )
+    |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layer_norm"))
   end
 
   defp classifier_dropout_rate(spec) do

--- a/lib/bumblebee/vision/clip_vision.ex
+++ b/lib/bumblebee/vision/clip_vision.ex
@@ -133,11 +133,7 @@ defmodule Bumblebee.Vision.ClipVision do
 
     pooler_output =
       encoder_outputs.hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "post_layernorm")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "post_layernorm"))
       |> Layers.take_token(index: 0, axis: 1, name: join(name, "head"))
 
     %{

--- a/lib/bumblebee/vision/deit.ex
+++ b/lib/bumblebee/vision/deit.ex
@@ -252,11 +252,7 @@ defmodule Bumblebee.Vision.Deit do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layernorm")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layernorm"))
 
     pooled = pooler(hidden_state, spec, name: join(name, "pooler"))
 
@@ -354,22 +350,14 @@ defmodule Bumblebee.Vision.Deit do
 
     {attention_output, attention} =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layernorm_before")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layernorm_before"))
       |> attention(spec, name: join(name, "attention"))
 
     attention_output = Axon.add(attention_output, hidden_state)
 
     output =
       attention_output
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layernorm_after")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layernorm_after"))
       |> intermediate(spec, name: join(name, "intermediate"))
       |> output(attention_output, spec, name: join(name, "output"))
 

--- a/lib/bumblebee/vision/vit.ex
+++ b/lib/bumblebee/vision/vit.ex
@@ -202,11 +202,7 @@ defmodule Bumblebee.Vision.Vit do
 
     hidden_state =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layernorm")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layernorm"))
 
     pooled = pooler(hidden_state, spec, name: join(name, "pooler"))
 
@@ -297,22 +293,14 @@ defmodule Bumblebee.Vision.Vit do
 
     {attention_output, attention} =
       hidden_state
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layernorm_before")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layernorm_before"))
       |> attention(spec, name: join(name, "attention"))
 
     attention_output = Axon.add(attention_output, hidden_state)
 
     output =
       attention_output
-      |> Axon.layer_norm(
-        channel_index: 2,
-        epsilon: spec.layer_norm_epsilon,
-        name: join(name, "layernorm_after")
-      )
+      |> Axon.layer_norm(epsilon: spec.layer_norm_epsilon, name: join(name, "layernorm_after"))
       |> intermediate(spec, name: join(name, "intermediate"))
       |> output(attention_output, spec, name: join(name, "output"))
 


### PR DESCRIPTION
Now `:channel_index` in `Axon.layer_norm` defaults to last, so we don't need to specify it explicitly.