### PR TITLE
Fix typos

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -607,7 +607,7 @@ defmodule Bumblebee do
   of subsequent timesteps for model forward pass.
 
   Note that the number of `timesteps` may not match `num_steps` exactly.
-  `num_steps` parameterizes sampling points, however depending on the
+  `num_steps` parametrizes sampling points, however depending on the
   method, sampling certain points may require multiple forward passes
   of the model and each element in `timesteps` corresponds to a single
   forward pass.

--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -607,7 +607,7 @@ defmodule Bumblebee do
   of subsequent timesteps for model forward pass.
 
   Note that the number of `timesteps` may not match `num_steps` exactly.
-  `num_steps` parametrizes sampling points, however depending on the
+  `num_steps` parameterizes sampling points, however depending on the
   method, sampling certain points may require multiple forward passes
   of the model and each element in `timesteps` corresponds to a single
   forward pass.

--- a/lib/bumblebee/utils/tokenizers.ex
+++ b/lib/bumblebee/utils/tokenizers.ex
@@ -86,7 +86,7 @@ defmodule Bumblebee.Utils.Tokenizers do
 
   defp maybe_put_offsets(encoded, encodings, return_offsets) do
     if return_offsets do
-      {batch_start_offets, batch_end_offsets} =
+      {batch_start_offsets, batch_end_offsets} =
         encodings
         |> Enum.map(fn seq ->
           seq |> Encoding.get_offsets() |> Enum.unzip()
@@ -94,7 +94,7 @@ defmodule Bumblebee.Utils.Tokenizers do
         |> Enum.unzip()
 
       encoded
-      |> Map.put("start_offsets", Nx.tensor(batch_start_offets))
+      |> Map.put("start_offsets", Nx.tensor(batch_start_offsets))
       |> Map.put("end_offsets", Nx.tensor(batch_end_offsets))
     else
       encoded


### PR DESCRIPTION
Found via `codespell -S deps` and `typos --format brief`