### PR TITLE
Normalize fill-mask output token

### DIFF
--- a/lib/bumblebee/text/fill_mask.ex
+++ b/lib/bumblebee/text/fill_mask.ex
@@ -89,7 +89,13 @@ defmodule Bumblebee.Text.FillMask do
             Nx.to_flat_list(top_scores),
             Nx.to_flat_list(top_indices),
             fn score, token_id ->
-              token = Bumblebee.Tokenizer.id_to_token(tokenizer, token_id)
+              # Certain tokenizers distinguish tokens with a leading space,
+              # so we normalize the result to a consistent string
+              token =
+                tokenizer
+                |> Bumblebee.Tokenizer.decode([token_id])
+                |> String.trim()
+
               %{score: score, token: token}
             end
           )


### PR DESCRIPTION
Some tokens are not particularly usable, for example `Ġcapital`, where corresponds to a leading space. This adds a normalization, such that the result is readable.