### PR TITLE
Pass scheduler to defn via options

### DIFF
--- a/lib/bumblebee/diffusion/ddim_scheduler.ex
+++ b/lib/bumblebee/diffusion/ddim_scheduler.ex
@@ -153,10 +153,12 @@ defmodule Bumblebee.Diffusion.DdimScheduler do
 
   @impl true
   def step(scheduler, state, sample, prediction) do
-    do_step(scheduler, state, sample, prediction)
+    do_step(state, sample, prediction, scheduler: scheduler)
   end
 
-  defnp do_step(scheduler \\ [], state, sample, prediction) do
+  defnp do_step(state, sample, prediction, opts) do
+    scheduler = opts[:scheduler]
+
     # See Equation (12)
 
     # Note that in the paper alpha_t represents a cumulative product,

--- a/lib/bumblebee/diffusion/pndm_scheduler.ex
+++ b/lib/bumblebee/diffusion/pndm_scheduler.ex
@@ -184,10 +184,12 @@ defmodule Bumblebee.Diffusion.PndmScheduler do
 
   @impl true
   def step(scheduler, state, sample, prediction) do
-    do_step(scheduler, state, sample, prediction)
+    do_step(state, sample, prediction, scheduler: scheduler)
   end
 
-  defnp do_step(scheduler \\ [], state, sample, noise) do
+  defnp do_step(state, sample, noise, opts) do
+    scheduler = opts[:scheduler]
+
     {state, prev} =
       if scheduler.reduce_warmup do
         step_just_plms(scheduler, state, sample, noise)


### PR DESCRIPTION
Closes #123.

We used to pass through all args with defaults in defn, but we changed to reserve that behaviour for lists, regardless of default arguments.