### PR TITLE
Add top-k option to zero-shot classification

### DIFF
--- a/lib/bumblebee/text.ex
+++ b/lib/bumblebee/text.ex
@@ -289,6 +289,10 @@ defmodule Bumblebee.Text do
 
   ## Options
 
+    * `:top_k` - the number of top predictions to include in the output. If
+      the configured value is higher than the number of labels, all
+      labels are returned. Defaults to `5`
+
     * `:hypothesis_template` - an arity-1 function which accepts a label
       and returns a hypothesis. The default hypothesis format is: "This example
       is #\{label\}".

--- a/test/bumblebee/text/zero_shot_classification_test.exs
+++ b/test/bumblebee/text/zero_shot_classification_test.exs
@@ -17,9 +17,9 @@ defmodule Bumblebee.Text.ZeroShotClassificationTest do
 
       assert %{
                predictions: [
-                 %{label: "cooking", score: _},
                  %{label: "traveling", score: _},
-                 %{label: "dancing", score: _}
+                 %{label: "dancing", score: _},
+                 %{label: "cooking", score: _}
                ]
              } = output
 


### PR DESCRIPTION
Similarly to other classification servings we have.