### PR TITLE
Explicitly tag files on speech to text

### DIFF
--- a/lib/bumblebee/audio.ex
+++ b/lib/bumblebee/audio.ex
@@ -10,10 +10,11 @@ defmodule Bumblebee.Audio do
 
     * a 1-dimensional `Nx.Tensor` with audio samples
 
-    * a path to an audio file (note this requires `ffmpeg` installed)
+    * `{:file, path}` with path to an audio file (note that this
+      requires `ffmpeg` installed)
 
   """
-  @type speech_to_text_input :: Nx.t() | String.t()
+  @type speech_to_text_input :: Nx.t() | {:file, String.t()}
   @type speech_to_text_output :: %{results: list(speech_to_text_result())}
   @type speech_to_text_result :: %{text: String.t()}
 
@@ -59,7 +60,7 @@ defmodule Bumblebee.Audio do
           defn_options: [compiler: EXLA]
         )
 
-      Nx.Serving.run(serving, "/path/to/audio.wav")
+      Nx.Serving.run(serving, {:file, "/path/to/audio.wav"})
       #=> %{results: [%{text: "There is a cat outside the window."}]}
 
   """

--- a/lib/bumblebee/audio/speech_to_text.ex
+++ b/lib/bumblebee/audio/speech_to_text.ex
@@ -41,14 +41,14 @@ defmodule Bumblebee.Audio.SpeechToText do
     |> Nx.Serving.client_preprocessing(fn input ->
       {inputs, multi?} =
         Shared.validate_serving_input!(input, fn
-          path when is_binary(path) ->
-            ffmpeg_read_as_pcm(path, sampling_rate)
-
           %Nx.Tensor{shape: {_}} = input ->
             {:ok, input}
 
+          {:file, path} when is_binary(path) ->
+            ffmpeg_read_as_pcm(path, sampling_rate)
+
           other ->
-            {:error, "expected a 1-dimensional tensor or a file path, got: #{inspect(other)}"}
+            {:error, "expected a 1-dimensional tensor or {:file, path}, got: #{inspect(other)}"}
         end)
 
       inputs = Bumblebee.apply_featurizer(featurizer, inputs, defn_options: defn_options)


### PR DESCRIPTION
We also wanted support for binary/stream input, but ffmpeg waits for stdin to be closed, which we can't do with ports.