### PR TITLE
Improve word aggregation with BIO tagging

### DIFF
--- a/lib/bumblebee/text/token_classification.ex
+++ b/lib/bumblebee/text/token_classification.ex
@@ -193,7 +193,7 @@ defmodule Bumblebee.Text.TokenClassification do
       {idx, score} = aggregate_word(group, strategy)
       label = spec.id_to_label[idx]
 
-      for {entity, idx} <- Enum.with_index(group) do
+      Enum.with_index(group, fn entity, idx ->
         label =
           if idx == 0 do
             label
@@ -202,7 +202,7 @@ defmodule Bumblebee.Text.TokenClassification do
           end
 
         %{entity | label: label, score: score}
-      end
+      end)
     end)
   end
 

--- a/lib/bumblebee/text/token_classification.ex
+++ b/lib/bumblebee/text/token_classification.ex
@@ -192,7 +192,17 @@ defmodule Bumblebee.Text.TokenClassification do
     |> Enum.flat_map(fn group ->
       {idx, score} = aggregate_word(group, strategy)
       label = spec.id_to_label[idx]
-      Enum.map(group, fn entity -> %{entity | label: label, score: score} end)
+
+      for {entity, idx} <- Enum.with_index(group) do
+        label =
+          if idx == 0 do
+            label
+          else
+            force_inside_label(label)
+          end
+
+        %{entity | label: label, score: score}
+      end
     end)
   end
 
@@ -259,4 +269,7 @@ defmodule Bumblebee.Text.TokenClassification do
   defp parse_label("B-" <> label), do: {:b, label}
   defp parse_label("I-" <> label), do: {:i, label}
   defp parse_label(label), do: {:i, label}
+
+  defp force_inside_label("B-" <> label), do: "I-" <> label
+  defp force_inside_label(label), do: label
 end

--- a/test/bumblebee/text/token_classification_test.exs
+++ b/test/bumblebee/text/token_classification_test.exs
@@ -70,40 +70,40 @@ defmodule Bumblebee.Text.TokenClassificationTest do
             aggregation: unquote(aggregation)
           )
 
-        text = "I went with Jane Doe to Atlanta and we talked to John Smith about Microsoft"
+        text = "I went with Janine Doe to Atlanta and we talked to John Smith about Microsoft"
 
         assert %{entities: [jane, atlanta, john, microsoft]} = Nx.Serving.run(serving, text)
 
         assert %{
                  label: "PER",
-                 score: _jane_score,
-                 phrase: "Jane Doe",
+                 score: _janine_score,
+                 phrase: "Janine Doe",
                  start: 12,
-                 end: 20
+                 end: 22
                } = jane
 
         assert %{
                  label: "LOC",
                  score: _atlanta_score,
                  phrase: "Atlanta",
-                 start: 24,
-                 end: 31
+                 start: 26,
+                 end: 33
                } = atlanta
 
         assert %{
                  label: "PER",
                  score: _john_score,
                  phrase: "John Smith",
-                 start: 49,
-                 end: 59
+                 start: 51,
+                 end: 61
                } = john
 
         assert %{
                  label: "ORG",
                  score: _microsoft_score,
                  phrase: "Microsoft",
-                 start: 66,
-                 end: 75
+                 start: 68,
+                 end: 77
                } = microsoft
       end
     end
@@ -118,7 +118,7 @@ defmodule Bumblebee.Text.TokenClassificationTest do
         )
 
       texts = [
-        "I went with Jane Doe to Atlanta and we talked to John Smith about Microsoft",
+        "I went with Janine Doe to Atlanta and we talked to John Smith about Microsoft",
         "John went to Philadelphia"
       ]
 


### PR DESCRIPTION
Follow up to #174.

For "Janine Doe" we get:

```
Jan   | B-PER
##ine | B-PER
Do    | I-PER
##e   | I-PER
```

When overriding word token labels we need to make sure that non-starting word tokens get the `I-` prefix, so they become a single label during further aggregation.