### PR TITLE
Add :no_repeat_ngram_length option to text generation

### DIFF
--- a/lib/bumblebee/shared.ex
+++ b/lib/bumblebee/shared.ex
@@ -56,7 +56,8 @@ defmodule Bumblebee.Shared do
       Keyword.validate!(defaults,
         forced_bos_token_id: nil,
         forced_eos_token_id: nil,
-        forced_token_ids: nil
+        forced_token_ids: nil,
+        no_repeat_ngram_length: nil
       )
 
     for {key, default} <- defaults do
@@ -113,7 +114,8 @@ defmodule Bumblebee.Shared do
       # Generation
       forced_bos_token_id: {"forced_bos_token_id", number()},
       forced_eos_token_id: {"forced_eos_token_id", number()},
-      forced_token_ids: {"forced_decoder_ids", list(tuple([number(), number()]))}
+      forced_token_ids: {"forced_decoder_ids", list(tuple([number(), number()]))},
+      no_repeat_ngram_length: {"no_repeat_ngram_size", number()}
     ]
 
     converters =

--- a/lib/bumblebee/text/generation.ex
+++ b/lib/bumblebee/text/generation.ex
@@ -603,8 +603,8 @@ defmodule Bumblebee.Text.Generation do
 
           batch_size = Nx.axis_size(logits, 0)
 
-          token_ids = sequences[[.., i + ngram_but_one_length]]
-          indices = Nx.stack([Nx.iota({batch_size}), token_ids], axis: -1)
+          token_id = sequences[[.., i + ngram_but_one_length]]
+          indices = Nx.stack([Nx.iota({batch_size}), token_id], axis: -1)
 
           match? = Nx.all(ngram_but_one == last_ngram_but_one, axes: [1])
           updates = Nx.select(match?, Nx.Constants.neg_infinity(), 0)


### PR DESCRIPTION
Prevents from n-gram (sequence of n tokens) duplication in generated text.