### PR TITLE
Don't log params diff if everything is loaded correctly

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -379,7 +379,8 @@ defmodule Bumblebee do
     * `:params_filename` - the file with the model parameters to be loaded
 
     * `:log_params_diff` - whether to log missing, mismatched and unused
-      parameters. Defaults to `true`
+      parameters. By default diff is logged only if some parameters
+      cannot be loaded
 
     * `:backend` - the backend to allocate the tensors on. It is either
       an atom or a tuple in the shape `{backend, options}`
@@ -416,7 +417,7 @@ defmodule Bumblebee do
         :architecture,
         :params_filename,
         :backend,
-        log_params_diff: true
+        :log_params_diff
       ])
 
     spec_response =
@@ -444,8 +445,6 @@ defmodule Bumblebee do
     # TODO: support format: :auto | :axon | :pytorch
     format = :pytorch
     filename = opts[:params_filename] || @params_filename[format]
-    log_params_diff = opts[:log_params_diff]
-    backend = opts[:backend]
 
     input_template = module.input_template(spec)
 
@@ -453,10 +452,11 @@ defmodule Bumblebee do
 
     with {:ok, path} <- download(repository, filename) do
       params =
-        Bumblebee.Conversion.PyTorch.load_params!(model, input_template, path,
-          log_params_diff: log_params_diff,
-          backend: backend,
-          params_mapping: params_mapping
+        Bumblebee.Conversion.PyTorch.load_params!(
+          model,
+          input_template,
+          path,
+          [params_mapping: params_mapping] ++ Keyword.take(opts, [:backend, :log_params_diff])
         )
 
       {:ok, params}

--- a/lib/bumblebee/diffusion/layers/unet.ex
+++ b/lib/bumblebee/diffusion/layers/unet.ex
@@ -316,6 +316,9 @@ defmodule Bumblebee.Diffusion.Layers.UNet do
       num_blocks: depth,
       num_attention_heads: num_heads,
       hidden_size: hidden_size,
+      query_use_bias: false,
+      key_use_bias: false,
+      value_use_bias: false,
       layer_norm: [
         epsilon: 1.0e-5
       ],

--- a/lib/bumblebee/huggingface/transformers/utils.ex
+++ b/lib/bumblebee/huggingface/transformers/utils.ex
@@ -28,7 +28,7 @@ defmodule Bumblebee.HuggingFace.Transformers.Utils do
   @spec map_params_source_layer_names(
           Transformers.Model.params_source(),
           (String.t() -> String.t())
-        ) :: Transformers.Model.params_source()
+        ) :: Transformers.Model.layer_name() | Transformers.Model.params_source()
   def map_params_source_layer_names(%{} = params_source, fun) do
     Map.new(params_source, fn {param_name, {sources, source_fun}} ->
       sources = for {layer_name, param_name} <- sources, do: {fun.(layer_name), param_name}


### PR DESCRIPTION
Closes #149.

Currently when all parameters are loaded as expected, we still show unused parameters, and for the end user it's likely more confusing than informative. This changes it, such that we only log if there are any missing/mismatched parameters. The `:log_params_diff` option can still be passed to force either behaviour.