### PR TITLE
Refactor embedding layers

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -119,6 +119,8 @@ defmodule Bumblebee do
     "ViTForImageClassification" => {Bumblebee.Vision.Vit, :for_image_classification},
     "ViTForMaskedImageModeling" => {Bumblebee.Vision.Vit, :for_masked_image_modeling},
     "ViTModel" => {Bumblebee.Vision.Vit, :base},
+    "WhisperModel" => {Bumblebee.Audio.Whisper, :base},
+    "WhisperForConditionalGeneration" => {Bumblebee.Audio.Whisper, :for_conditional_generation},
     # These models are just RoBERTa models, but the config will list them as XLM-RoBERTa
     "XLMRobertaForCausalLM" => {Bumblebee.Text.Roberta, :for_causal_language_modeling},
     "XLMRobertaForMaskedLM" => {Bumblebee.Text.Roberta, :for_masked_language_modeling},
@@ -128,8 +130,6 @@ defmodule Bumblebee do
       {Bumblebee.Text.Roberta, :for_sequence_classification},
     "XLMRobertaForTokenClassification" => {Bumblebee.Text.Roberta, :for_token_classification},
     "XLMRobertaModel" => {Bumblebee.Text.Roberta, :base},
-    "WhisperModel" => {Bumblebee.Audio.Whisper, :base},
-    "WhisperForConditionalGeneration" => {Bumblebee.Audio.Whisper, :for_conditional_generation},
     # Diffusers
     "AutoencoderKL" => {Bumblebee.Diffusion.VaeKl, :base},
     "StableDiffusionSafetyChecker" => {Bumblebee.Diffusion.StableDiffusion.SafetyChecker, :base},

--- a/lib/bumblebee/vision/clip_vision.ex
+++ b/lib/bumblebee/vision/clip_vision.ex
@@ -136,11 +136,13 @@ defmodule Bumblebee.Vision.ClipVision do
 
     patch_embeddings = patch_embedding(pixel_values, spec, name: join(name, "patch_embedding"))
 
-    input_embeddings =
-      Layers.prepend_embedding(patch_embeddings,
+    class_embedding =
+      Layers.learned_embeddings(1, spec.hidden_size,
         name: join(name, "class_embedding"),
         initializer: Axon.Initializers.normal()
       )
+
+    input_embeddings = Layers.concatenate_embeddings([class_embedding, patch_embeddings])
 
     num_patches = div(spec.image_size, spec.patch_size) ** 2
     num_positions = num_patches + 1
@@ -232,9 +234,9 @@ defmodule Bumblebee.Vision.ClipVision do
       %{
         "embedder.patch_embedding" => "vision_model.embeddings.patch_embedding",
         "embedder.class_embedding" => %{
-          "embedding" => {
+          "embeddings" => {
             [{"vision_model.embeddings", "class_embedding"}],
-            fn [value] -> value end
+            fn [value] -> Nx.new_axis(value, 0) end
           }
         },
         "embedder.position_embedding" => "vision_model.embeddings.position_embedding",

--- a/lib/bumblebee/vision/deit.ex
+++ b/lib/bumblebee/vision/deit.ex
@@ -267,10 +267,14 @@ defmodule Bumblebee.Vision.Deit do
       |> patch_embedding(spec, name: join(name, "patch_embedding"))
       |> Layers.apply_vision_patch_mask(patch_mask, name: join(name, "mask_tokens"))
 
+    class_embedding =
+      Layers.learned_embeddings(1, spec.hidden_size, name: join(name, "class_embedding"))
+
+    distillation_embedding =
+      Layers.learned_embeddings(1, spec.hidden_size, name: join(name, "distillation_embedding"))
+
     input_embeddings =
-      patch_embeddings
-      |> Layers.prepend_embedding(name: join(name, "distillation_embedding"))
-      |> Layers.prepend_embedding(name: join(name, "class_embedding"))
+      Layers.concatenate_embeddings([class_embedding, distillation_embedding, patch_embeddings])
 
     num_patches = div(spec.image_size, spec.patch_size) ** 2
 
@@ -371,15 +375,15 @@ defmodule Bumblebee.Vision.Deit do
       %{
         "embedder.patch_embedding.projection" => "deit.embeddings.patch_embeddings.projection",
         "embedder.distillation_embedding" => %{
-          "embedding" => {
+          "embeddings" => {
             [{"deit.embeddings", "distillation_token"}],
-            fn [value] -> Nx.squeeze(value, axes: [0, 1]) end
+            fn [value] -> Nx.squeeze(value, axes: [0]) end
           }
         },
         "embedder.class_embedding" => %{
-          "embedding" => {
+          "embeddings" => {
             [{"deit.embeddings", "cls_token"}],
-            fn [value] -> Nx.squeeze(value, axes: [0, 1]) end
+            fn [value] -> Nx.squeeze(value, axes: [0]) end
           }
         },
         "embedder.position_embedding" => %{


### PR DESCRIPTION
We currently have `prepend_embedding` layer for adding embedding for single tokens (like CLS), but I generalized it, such that we just use `embeddings` with whatever shape (could be length-1) and then do `prepend_embedding`.

This was primarily for YOLOS, which I realised relies on dynamic shapes too much, but these changes are useful anyway.