### PR TITLE
Add GPT-NeoX (StableLM)

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -117,6 +117,8 @@ defmodule Bumblebee do
     "GPT2ForTokenClassification" => {Bumblebee.Text.Gpt2, :for_token_classification},
     "GPT2LMHeadModel" => {Bumblebee.Text.Gpt2, :for_causal_language_modeling},
     "GPT2Model" => {BumbleBee.Text.Gpt2, :base},
+    "GPTNeoXModel" => {Bumblebee.Text.GptNeoX, :base},
+    "GPTNeoXForCausalLM" => {Bumblebee.Text.GptNeoX, :for_causal_language_modeling},
     "LayoutLMForMaskedLanguageModeling" =>
       {Bumblebee.Multimodal.LayoutLm, :for_masked_language_modeling},
     "LayoutLMForQuestionAnswering" => {Bumblebee.Multimodal.LayoutLm, :for_question_answering},

--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -199,6 +199,7 @@ defmodule Bumblebee do
     "distilbert" => Bumblebee.Text.DistilbertTokenizer,
     "camembert" => Bumblebee.Text.CamembertTokenizer,
     "clip" => Bumblebee.Text.ClipTokenizer,
+    "gpt_neox" => Bumblebee.Text.GptNeoXTokenizer,
     "gpt2" => Bumblebee.Text.Gpt2Tokenizer,
     "layoutlm" => Bumblebee.Text.LayoutLmTokenizer,
     "llama" => Bumblebee.Text.LlamaTokenizer,

--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -119,6 +119,8 @@ defmodule Bumblebee do
     "GPT2Model" => {BumbleBee.Text.Gpt2, :base},
     "GPTNeoXModel" => {Bumblebee.Text.GptNeoX, :base},
     "GPTNeoXForCausalLM" => {Bumblebee.Text.GptNeoX, :for_causal_language_modeling},
+    "GPTNeoXForSequenceClassification" => {Bumblebee.Text.GptNeoX, :for_sequence_classification},
+    "GPTNeoXForTokenClassification" => {Bumblebee.Text.GptNeoX, :for_token_classification},
     "LayoutLMForMaskedLanguageModeling" =>
       {Bumblebee.Multimodal.LayoutLm, :for_masked_language_modeling},
     "LayoutLMForQuestionAnswering" => {Bumblebee.Multimodal.LayoutLm, :for_question_answering},

--- a/lib/bumblebee/audio/whisper.ex
+++ b/lib/bumblebee/audio/whisper.ex
@@ -428,11 +428,11 @@ defmodule Bumblebee.Audio.Whisper do
         layer_norm: [
           epsilon: 1.0e-5
         ],
-        norm_placement: :first,
         ffn: [
           intermediate_size: spec.encoder_intermediate_size,
           activation: spec.activation
         ],
+        block_type: :norm_first,
         output_hidden_states: spec.output_hidden_states,
         output_attentions: spec.output_attentions,
         name: join(name, "blocks")
@@ -477,11 +477,11 @@ defmodule Bumblebee.Audio.Whisper do
         layer_norm: [
           epsilon: 1.0e-5
         ],
-        norm_placement: :first,
         ffn: [
           intermediate_size: spec.decoder_intermediate_size,
           activation: spec.activation
         ],
+        block_type: :norm_first,
         output_hidden_states: spec.output_hidden_states,
         output_attentions: spec.output_attentions,
         name: join(name, "blocks")

--- a/lib/bumblebee/diffusion/layers/unet.ex
+++ b/lib/bumblebee/diffusion/layers/unet.ex
@@ -323,8 +323,8 @@ defmodule Bumblebee.Diffusion.Layers.UNet do
         epsilon: 1.0e-5
       ],
       dropout_rate: dropout,
-      norm_placement: :first,
       ffn: &ffn_geglu(&1, hidden_size, dropout: dropout, name: &2),
+      block_type: :norm_first,
       name: join(name, "blocks")
     )
     |> then(fn %{hidden_state: hidden_state} ->

--- a/lib/bumblebee/layers.ex
+++ b/lib/bumblebee/layers.ex
@@ -979,7 +979,7 @@ defmodule Bumblebee.Layers do
   end
 
   deftransformp create_sinusoidal_positions(max_positions, size, base) do
-    range = Nx.multiply(Nx.iota({div(size, 2)}), 2)
+    range = Nx.iota({div(size, 2)}) |> Nx.multiply(2) |> Nx.divide(size)
     inv_frequency = Nx.divide(1.0, Nx.pow(base, range))
 
     position = Nx.iota({max_positions})

--- a/lib/bumblebee/layers/decoder.ex
+++ b/lib/bumblebee/layers/decoder.ex
@@ -59,14 +59,14 @@ defmodule Bumblebee.Layers.Decoder do
     decoder_head_size =
       opts[:attention_head_size] || div(hidden_size, decoder_num_attention_heads)
 
-    encoder_head_size =
-      opts[:attention_head_size] || div(hidden_size, encoder_num_attention_heads)
-
     self_attention =
       attention_cache(batch_size, max_length, decoder_num_attention_heads, decoder_head_size)
 
     cross_attention =
       if encoder_sequence_length do
+        encoder_head_size =
+          opts[:attention_head_size] || div(hidden_size, encoder_num_attention_heads)
+
         attention_cache(
           batch_size,
           encoder_sequence_length,

--- a/lib/bumblebee/text/blenderbot.ex
+++ b/lib/bumblebee/text/blenderbot.ex
@@ -404,11 +404,11 @@ defmodule Bumblebee.Text.Blenderbot do
         layer_norm: [
           epsilon: 1.0e-5
         ],
-        norm_placement: :first,
         ffn: [
           intermediate_size: spec.encoder_intermediate_size,
           activation: spec.activation
         ],
+        block_type: :norm_first,
         output_hidden_states: spec.output_hidden_states,
         output_attentions: spec.output_attentions,
         name: join(name, "blocks")
@@ -454,11 +454,11 @@ defmodule Bumblebee.Text.Blenderbot do
         layer_norm: [
           epsilon: 1.0e-5
         ],
-        norm_placement: :first,
         ffn: [
           intermediate_size: spec.decoder_intermediate_size,
           activation: spec.activation
         ],
+        block_type: :norm_first,
         output_hidden_states: spec.output_hidden_states,
         output_attentions: spec.output_attentions,
         name: join(name, "blocks")

--- a/lib/bumblebee/text/clip_text.ex
+++ b/lib/bumblebee/text/clip_text.ex
@@ -194,11 +194,11 @@ defmodule Bumblebee.Text.ClipText do
       layer_norm: [
         epsilon: spec.layer_norm_epsilon
       ],
-      norm_placement: :first,
       ffn: [
         intermediate_size: spec.intermediate_size,
         activation: spec.activation
       ],
+      block_type: :norm_first,
       output_hidden_states: spec.output_hidden_states,
       output_attentions: spec.output_attentions,
       name: join(name, "blocks")

--- a/lib/bumblebee/text/gpt2.ex
+++ b/lib/bumblebee/text/gpt2.ex
@@ -404,11 +404,11 @@ defmodule Bumblebee.Text.Gpt2 do
         layer_norm: [
           epsilon: spec.layer_norm_epsilon
         ],
-        norm_placement: :first,
         ffn: [
           intermediate_size: spec.intermediate_size || 4 * spec.hidden_size,
           activation: spec.activation
         ],
+        block_type: :norm_first,
         output_hidden_states: spec.output_hidden_states,
         output_attentions: spec.output_attentions,
         name: join(name, "blocks")

--- a/lib/bumblebee/text/gpt_neo_x.ex
+++ b/lib/bumblebee/text/gpt_neo_x.ex
@@ -1,0 +1,386 @@
+defmodule Bumblebee.Text.GptNeoX do
+  alias Bumblebee.Shared
+
+  options =
+    [
+      vocab_size: [
+        default: 32000,
+        doc: """
+        the vocabulary size of the token embedding. This corresponds to the number of distinct
+        tokens that can be represented in model input and output
+        """
+      ],
+      hidden_size: [
+        default: 4096,
+        doc: "the dimensionality of hidden layers"
+      ],
+      intermediate_size: [
+        default: 11008,
+        doc: "the dimensionality of intermediate layers"
+      ],
+      num_blocks: [
+        default: 32,
+        doc: "the number of Transformer blocks in the model"
+      ],
+      num_attention_heads: [
+        default: 32,
+        doc: "the number of attention heads for each attention layer in the model"
+      ],
+      activation: [
+        default: :silu,
+        doc: "the activation function"
+      ],
+      rotary_percentage: [
+        default: 0.25,
+        doc: "percentage of hidden dimensions to allocate to rotary embeddings"
+      ],
+      rotary_embedding_base: [
+        default: 10_000,
+        doc: "base for computing rotary embedding frequency"
+      ],
+      layer_norm_epsilon: [
+        default: 1.0e-12,
+        doc: "the epsilon used by RMS normalization layers"
+      ],
+      initializer_scale: [
+        default: 0.02,
+        doc:
+          "the standard deviation of the normal initializer used for initializing kernel parameters"
+      ]
+    ] ++
+      Shared.common_options([
+        :output_hidden_states,
+        :output_attentions,
+        :num_labels,
+        :id_to_label
+      ]) ++
+      Shared.token_options(
+        pad_token_id: 0,
+        bos_token_id: 1,
+        eos_token_id: 2
+      )
+
+  @moduledoc """
+  GPT-NeoX model family.
+
+  ## Architectures
+
+    * `:base` - plain GPT-NeoX without any head on top
+
+    * `:for_causal_language_modeling` - GPT-NeoX with a language modeling
+      head. The head returns logits for each token in the original
+      sequence
+
+    * `:for_sequence_classification` - GPT-NeoX with a sequence
+      classification head. The head returns logits corresponding to
+      possible classes
+
+  ## Inputs
+
+    * `"input_ids"` - `{batch_size, sequence_length}`
+
+      Indices of input sequence tokens in the vocabulary.
+
+    * `"attention_mask"` - `{batch_size, sequence_length}`
+
+      Mask indicating which tokens to attend to. This is used to ignore
+      padding tokens, which are added when processing a batch of sequences
+      with different length.
+
+    * `"position_ids"` - `{batch_size, sequence_length}`
+
+      Indices of positions of each input sequence tokens in the position
+      embeddings.
+
+    * `"attention_head_mask"` - `{encoder_num_blocks, encoder_num_attention_heads}`
+
+      Mask to nullify selected heads of the self-attention blocks in
+      the encoder.
+
+    * `"input_embeddings"` - `{batch_size, sequence_length, hidden_size}`
+
+      Embedded representation of `"input_ids"`, which can be specified
+      for more control over how `"input_ids"` are embedded than the
+      model's internal embedding lookup. If `"input_embeddings"` are present,
+      then `"input_ids"` will be ignored.
+
+    * `"cache"`
+
+      A container with cached layer results used to speed up sequential
+      decoding (autoregression). With cache, certain hidden states are
+      taken from the cache, rather than recomputed on every decoding
+      pass. The cache should be treated as opaque and initialized with
+      `Bumblebee.Text.Generation.init_cache/4`.
+
+  ### Exceptions
+
+  The `:for_causal_language_modeling` model is just the decoder part and
+  accepts the following inputs instead: `"input_ids"`, `"attention_mask"`,
+  `"position_ids"`, `"attention_head_mask"`, `"input_embeddings"`, `"encoder_hidden_state"`,
+  `"encoder_attention_mask"`, `"cross_attention_head_mask"`, `"cache"`.
+
+  ## Configuration
+
+  #{Shared.options_doc(options)}
+  """
+
+  defstruct [architecture: :base] ++ Shared.option_defaults(options)
+
+  @behaviour Bumblebee.ModelSpec
+  @behaviour Bumblebee.Configurable
+  @behaviour Bumblebee.Text.Generation
+
+  import Bumblebee.Utils.Model, only: [join: 2]
+
+  alias Bumblebee.Layers
+
+  @impl true
+  def architectures(),
+    do: [
+      :base,
+      :for_causal_language_modeling,
+      :for_sequence_classification
+    ]
+
+  @impl true
+  def config(spec, opts \\ []) do
+    spec
+    |> Shared.put_config_attrs(opts)
+    |> Shared.validate_label_options()
+  end
+
+  @impl true
+  def input_template(_spec) do
+    %{
+      "input_ids" => Nx.template({1, 1}, :s64)
+    }
+  end
+
+  @impl true
+  def init_cache(spec, batch_size, max_length, _inputs) do
+    Layers.Decoder.init_cache(batch_size, max_length,
+      hidden_size: spec.hidden_size,
+      decoder_num_attention_heads: spec.num_attention_heads,
+      decoder_num_blocks: spec.num_blocks
+    )
+  end
+
+  @impl true
+  def traverse_cache(_spec, cache, fun) do
+    Layers.Decoder.traverse_cache(cache, fun)
+  end
+
+  @impl true
+  def model(%__MODULE__{architecture: :base} = spec) do
+    inputs = inputs(spec)
+
+    inputs
+    |> core(spec)
+    |> Layers.output()
+  end
+
+  def model(%__MODULE__{architecture: :for_causal_language_modeling} = spec) do
+    inputs = inputs(spec)
+
+    outputs = core(inputs, spec)
+    logits = language_modeling_head(outputs.hidden_state, spec, name: "language_modeling_head")
+
+    Layers.output(%{
+      logits: logits,
+      hidden_states: outputs.hidden_states,
+      attentions: outputs.attentions,
+      cache: outputs.cache
+    })
+  end
+
+  defp inputs(spec) do
+    shape = {nil, nil}
+    hidden_shape = {nil, nil, spec.hidden_size}
+
+    attention_head_mask_shape = {spec.num_blocks, spec.num_attention_heads}
+
+    Bumblebee.Utils.Model.inputs_to_map([
+      Axon.input("input_ids", optional: true, shape: shape),
+      Axon.input("attention_mask", optional: true, shape: shape),
+      Axon.input("position_ids", optional: true, shape: shape),
+      Axon.input("attention_head_mask", optional: true, shape: attention_head_mask_shape),
+      Axon.input("input_embeddings", optional: true, shape: hidden_shape),
+      Axon.input("cache", optional: true)
+    ])
+  end
+
+  defp core(inputs, spec) do
+    embeddings =
+      embedder(
+        inputs["input_ids"],
+        inputs["input_embeddings"],
+        spec,
+        name: "embedder"
+      )
+
+    position_ids =
+      Layers.default inputs["position_ids"] do
+        Layers.default_position_ids(embeddings)
+      end
+
+    decoder_outputs =
+      decoder(
+        embeddings,
+        position_ids,
+        inputs["attention_mask"],
+        inputs["attention_head_mask"],
+        inputs["cache"],
+        spec,
+        name: "decoder"
+      )
+
+    hidden_state =
+      Axon.layer_norm(decoder_outputs.hidden_state,
+        name: "output_norm",
+        epsilon: spec.layer_norm_epsilon
+      )
+
+    %{
+      hidden_state: hidden_state,
+      hidden_states: Layers.append(decoder_outputs.hidden_states, hidden_state),
+      attentions: decoder_outputs.attentions,
+      cache: decoder_outputs.cache
+    }
+  end
+
+  defp embedder(input_ids, input_embeddings, spec, opts) do
+    name = opts[:name]
+
+    Layers.default input_embeddings do
+      Axon.embedding(input_ids, spec.vocab_size, spec.hidden_size,
+        kernel_initializer: kernel_initializer(spec),
+        name: join(name, "token_embedding")
+      )
+    end
+  end
+
+  defp decoder(
+         hidden_state,
+         position_ids,
+         attention_mask,
+         attention_head_mask,
+         cache,
+         spec,
+         opts
+       ) do
+    name = opts[:name]
+
+    Layers.Transformer.blocks(hidden_state,
+      position_ids: position_ids,
+      attention_mask: attention_mask,
+      attention_head_mask: attention_head_mask,
+      cache: cache,
+      num_blocks: spec.num_blocks,
+      num_attention_heads: spec.num_attention_heads,
+      hidden_size: spec.hidden_size,
+      kernel_initializer: kernel_initializer(spec),
+      layer_norm: [
+        epsilon: spec.layer_norm_epsilon
+      ],
+      norm_placement: :first,
+      ffn: [
+        intermediate_size: spec.intermediate_size
+      ],
+      causal?: true,
+      use_rotary_embedding?: true,
+      rotary_embedding_base: spec.rotary_embedding_base,
+      rotary_percentage: spec.rotary_percentage,
+      query_use_bias: true,
+      key_use_bias: true,
+      value_use_bias: true,
+      output_use_bias: true,
+      output_hidden_states: spec.output_hidden_states,
+      output_attentions: spec.output_attentions,
+      name: join(name, "blocks")
+    )
+  end
+
+  defp language_modeling_head(hidden_state, spec, opts) do
+    name = opts[:name]
+
+    # TODO: Tie lm-head to word embedding as a spec option
+    Layers.dense_transposed(hidden_state, spec.vocab_size,
+      kernel_initializer: kernel_initializer(spec),
+      name: join(name, "output")
+    )
+  end
+
+  defp kernel_initializer(spec) do
+    Axon.Initializers.normal(scale: spec.initializer_scale)
+  end
+
+  defimpl Bumblebee.HuggingFace.Transformers.Config do
+    def load(spec, data) do
+      import Shared.Converters
+
+      opts =
+        convert!(data,
+          vocab_size: {"vocab_size", number()},
+          max_positions: {"max_positions", number()},
+          hidden_size: {"hidden_size", number()},
+          num_blocks: {"num_hidden_layers", number()},
+          num_attention_heads: {"num_attention_heads", number()},
+          intermediate_size: {"intermediate_size", number()},
+          activation: {"hidden_act", atom()},
+          dropout_rate: {"dropout", number()},
+          initializer_scale: {"init_std", number()},
+          layer_norm_epsilon: {"layer_norm_eps", number()}
+        ) ++ Shared.common_options_from_transformers(data, spec)
+
+      @for.config(spec, opts)
+    end
+  end
+
+  defimpl Bumblebee.HuggingFace.Transformers.Model do
+    def params_mapping(_spec) do
+      %{
+        "embedder.token_embedding" => "gpt_neox.embed_in",
+        "decoder.blocks.{n}.self_attention.query" =>
+          sliced_dense("gpt_neox.layers.{n}.attention.query_key_value", 3, 0),
+        "decoder.blocks.{n}.self_attention.key" =>
+          sliced_dense("gpt_neox.layers.{n}.attention.query_key_value", 3, 1),
+        "decoder.blocks.{n}.self_attention.value" =>
+          sliced_dense("gpt_neox.layers.{n}.attention.query_key_value", 3, 2),
+        "decoder.blocks.{n}.self_attention.output" => "gpt_neox.layers.{n}.attention.dense",
+        "decoder.blocks.{n}.self_attention_norm" => "gpt_neox.layers.{n}.input_layernorm",
+        "decoder.blocks.{n}.self_attention.rotary_embedding" =>
+          "gpt_neox.layers.{n}.self_attn.rotary_emb",
+        "decoder.blocks.{n}.ffn.intermediate" => "gpt_neox.layers.{n}.mlp.dense_h_to_4h",
+        "decoder.blocks.{n}.ffn.output" => "gpt_neox.layers.{n}.mlp.dense_4h_to_h",
+        "decoder.blocks.{n}.output_norm" => "gpt_neox.layers.{n}.post_attention_layernorm",
+        "output_norm" => "gpt_neox.final_layer_norm",
+        "language_modeling_head.output" => "embed_out"
+      }
+    end
+
+    defp sliced_dense(source_layer_name, num_chunks, idx) do
+      %{
+        "kernel" => {
+          [{source_layer_name, "weight"}],
+          fn [kernel] ->
+            # Slice units
+            size = Nx.axis_size(kernel, 0)
+            step = div(size, num_chunks)
+            kernel = Nx.slice_along_axis(kernel, idx * step, step, axis: 0)
+            # Transpose the kernel
+            [out_features, in_features] = Nx.axes(kernel)
+            Nx.transpose(kernel, axes: [in_features, out_features])
+          end
+        },
+        "bias" => {
+          [{source_layer_name, "bias"}],
+          fn [bias] ->
+            size = Nx.axis_size(bias, 0)
+            step = div(size, num_chunks)
+            Nx.slice_along_axis(bias, idx * step, step)
+          end
+        }
+      }
+    end
+  end
+end

--- a/lib/bumblebee/text/gpt_neo_x.ex
+++ b/lib/bumblebee/text/gpt_neo_x.ex
@@ -57,12 +57,7 @@ defmodule Bumblebee.Text.GptNeoX do
         :output_attentions,
         :num_labels,
         :id_to_label
-      ]) ++
-      Shared.token_options(
-        pad_token_id: 0,
-        bos_token_id: 1,
-        eos_token_id: 2
-      )
+      ]) ++ Shared.token_options(pad_token_id: nil)
 
   @moduledoc """
   GPT-NeoX model family.
@@ -119,13 +114,6 @@ defmodule Bumblebee.Text.GptNeoX do
       taken from the cache, rather than recomputed on every decoding
       pass. The cache should be treated as opaque and initialized with
       `Bumblebee.Text.Generation.init_cache/4`.
-
-  ### Exceptions
-
-  The `:for_causal_language_modeling` model is just the decoder part and
-  accepts the following inputs instead: `"input_ids"`, `"attention_mask"`,
-  `"position_ids"`, `"attention_head_mask"`, `"input_embeddings"`, `"encoder_hidden_state"`,
-  `"encoder_attention_mask"`, `"cross_attention_head_mask"`, `"cache"`.
 
   ## Configuration
 

--- a/lib/bumblebee/text/gpt_neo_x.ex
+++ b/lib/bumblebee/text/gpt_neo_x.ex
@@ -50,6 +50,11 @@ defmodule Bumblebee.Text.GptNeoX do
         default: 0.02,
         doc:
           "the standard deviation of the normal initializer used for initializing kernel parameters"
+      ],
+      use_parallel_transformer_block: [
+        default: true,
+        doc:
+          "whether to use the parallel formulation of the Transformer block, where attention and FFN is computed independently"
       ]
     ] ++
       Shared.common_options([
@@ -343,7 +348,7 @@ defmodule Bumblebee.Text.GptNeoX do
       ffn: [
         intermediate_size: spec.intermediate_size
       ],
-      block_type: :parallel,
+      block_type: if(spec.use_parallel_transformer_block, do: :parallel, else: :norm_first),
       causal?: true,
       rotary_embedding: [
         position_ids: position_ids,
@@ -391,7 +396,8 @@ defmodule Bumblebee.Text.GptNeoX do
           rotary_embedding_base: {"rotary_emb_base", number()},
           classifier_dropout_rate: {"classifier_dropout", number()},
           layer_norm_epsilon: {"layer_norm_eps", number()},
-          initializer_scale: {"init_std", number()}
+          initializer_scale: {"init_std", number()},
+          use_parallel_transformer_block: {"use_parallel_residual", boolean()}
         ) ++ Shared.common_options_from_transformers(data, spec)
 
       @for.config(spec, opts)

--- a/lib/bumblebee/text/gpt_neo_x.ex
+++ b/lib/bumblebee/text/gpt_neo_x.ex
@@ -281,10 +281,10 @@ defmodule Bumblebee.Text.GptNeoX do
       layer_norm: [
         epsilon: spec.layer_norm_epsilon
       ],
-      norm_placement: :first,
       ffn: [
         intermediate_size: spec.intermediate_size
       ],
+      block_type: :parallel,
       causal?: true,
       rotary_embedding: [
         position_ids: position_ids,

--- a/lib/bumblebee/text/gpt_neo_x_tokenizer.ex
+++ b/lib/bumblebee/text/gpt_neo_x_tokenizer.ex
@@ -1,0 +1,29 @@
+defmodule Bumblebee.Text.GptNeoXTokenizer do
+  @moduledoc """
+  GPT-NeoX tokenizer.
+  """
+
+  @behaviour Bumblebee.Text.Conversation
+
+  import Bumblebee.Shared
+
+  tokenizer_impl(
+    special_tokens: %{
+      unk: "<|endoftext|>",
+      bos: "<|endoftext|>",
+      eos: "<|endoftext|>",
+      # GPT-NeoX doesn't originally have a pad token, however when necessary
+      # we pad with the EOS token
+      pad: "<|endoftext|>"
+    }
+  )
+
+  @impl true
+  def conversation_history_to_text(tokenizer, history) do
+    eos_token = tokenizer.special_tokens.eos
+
+    history
+    |> Enum.reverse()
+    |> Enum.map_join(&(elem(&1, 1) <> eos_token))
+  end
+end

--- a/lib/bumblebee/text/llama.ex
+++ b/lib/bumblebee/text/llama.ex
@@ -312,12 +312,12 @@ defmodule Bumblebee.Text.Llama do
       hidden_size: spec.hidden_size,
       kernel_initializer: kernel_initializer(spec),
       layer_norm: &Layers.rms_norm(&1, name: &2, epsilon: spec.layer_norm_epsilon),
-      norm_placement: :first,
       ffn:
         &gated_ffn(&1, spec.intermediate_size, spec.hidden_size,
           name: &2,
           activation: spec.activation
         ),
+      block_type: :norm_first,
       causal?: true,
       rotary_embedding: [position_ids: position_ids, max_positions: spec.max_positions],
       query_use_bias: false,

--- a/lib/bumblebee/text/llama.ex
+++ b/lib/bumblebee/text/llama.ex
@@ -53,7 +53,7 @@ defmodule Bumblebee.Text.Llama do
         :output_attentions,
         :num_labels,
         :id_to_label
-      ]) ++ Shared.token_options(pad_token_id: nil)
+      ]) ++ Shared.token_options(pad_token_id: 0)
 
   @moduledoc """
   LLaMA model family.
@@ -106,13 +106,6 @@ defmodule Bumblebee.Text.Llama do
       taken from the cache, rather than recomputed on every decoding
       pass. The cache should be treated as opaque and initialized with
       `Bumblebee.Text.Generation.init_cache/4`.
-
-  ### Exceptions
-
-  The `:for_causal_language_modeling` model is just the decoder part and
-  accepts the following inputs instead: `"input_ids"`, `"attention_mask"`,
-  `"position_ids"`, `"attention_head_mask"`, `"input_embeddings"`, `"encoder_hidden_state"`,
-  `"encoder_attention_mask"`, `"cross_attention_head_mask"`, `"cache"`.
 
   ## Configuration
 

--- a/lib/bumblebee/text/llama.ex
+++ b/lib/bumblebee/text/llama.ex
@@ -53,7 +53,7 @@ defmodule Bumblebee.Text.Llama do
         :output_attentions,
         :num_labels,
         :id_to_label
-      ]) ++ Shared.token_options(pad_token_id: 0)
+      ]) ++ Shared.token_options(pad_token_id: nil)
 
   @moduledoc """
   LLaMA model family.

--- a/lib/bumblebee/text/mbart.ex
+++ b/lib/bumblebee/text/mbart.ex
@@ -528,7 +528,7 @@ defmodule Bumblebee.Text.Mbart do
         layer_norm: [
           epsilon: 1.0e-5
         ],
-        norm_placement: :first,
+        block_type: :norm_first,
         ffn: [
           intermediate_size: spec.encoder_intermediate_size,
           activation: spec.activation
@@ -626,7 +626,7 @@ defmodule Bumblebee.Text.Mbart do
         layer_norm: [
           epsilon: 1.0e-5
         ],
-        norm_placement: :first,
+        block_type: :norm_first,
         ffn: [
           intermediate_size: spec.decoder_intermediate_size,
           activation: spec.activation

--- a/lib/bumblebee/utils/axon.ex
+++ b/lib/bumblebee/utils/axon.ex
@@ -47,7 +47,7 @@ defmodule Bumblebee.Utils.Axon do
         {fun.(left, right), right_leaves}
 
       {left, right} ->
-        {do_zip_with(left, right, fun), right_leaves}
+        {container_zip_with(left, right, fun), right_leaves}
     end
   end
 

--- a/lib/bumblebee/vision/blip_vision.ex
+++ b/lib/bumblebee/vision/blip_vision.ex
@@ -188,11 +188,11 @@ defmodule Bumblebee.Vision.BlipVision do
       layer_norm: [
         epsilon: spec.layer_norm_epsilon
       ],
-      norm_placement: :first,
       ffn: [
         intermediate_size: spec.intermediate_size,
         activation: spec.activation
       ],
+      block_type: :norm_first,
       output_hidden_states: spec.output_hidden_states,
       output_attentions: spec.output_attentions,
       name: join(name, "blocks")

--- a/lib/bumblebee/vision/clip_vision.ex
+++ b/lib/bumblebee/vision/clip_vision.ex
@@ -192,11 +192,11 @@ defmodule Bumblebee.Vision.ClipVision do
       layer_norm: [
         epsilon: spec.layer_norm_epsilon
       ],
-      norm_placement: :first,
       ffn: [
         intermediate_size: spec.intermediate_size,
         activation: spec.activation
       ],
+      block_type: :norm_first,
       output_hidden_states: spec.output_hidden_states,
       output_attentions: spec.output_attentions,
       name: join(name, "blocks")

--- a/lib/bumblebee/vision/deit.ex
+++ b/lib/bumblebee/vision/deit.ex
@@ -318,11 +318,11 @@ defmodule Bumblebee.Vision.Deit do
       layer_norm: [
         epsilon: spec.layer_norm_epsilon
       ],
-      norm_placement: :first,
       ffn: [
         intermediate_size: spec.intermediate_size,
         activation: spec.activation
       ],
+      block_type: :norm_first,
       output_hidden_states: spec.output_hidden_states,
       output_attentions: spec.output_attentions,
       name: join(name, "blocks")

--- a/lib/bumblebee/vision/vit.ex
+++ b/lib/bumblebee/vision/vit.ex
@@ -268,11 +268,11 @@ defmodule Bumblebee.Vision.Vit do
       layer_norm: [
         epsilon: spec.layer_norm_epsilon
       ],
-      norm_placement: :first,
       ffn: [
         intermediate_size: spec.intermediate_size,
         activation: spec.activation
       ],
+      block_type: :norm_first,
       output_hidden_states: spec.output_hidden_states,
       output_attentions: spec.output_attentions,
       name: join(name, "blocks")

--- a/test/bumblebee/text/gpt_neo_x_test.exs
+++ b/test/bumblebee/text/gpt_neo_x_test.exs
@@ -1,0 +1,83 @@
+defmodule Bumblebee.Text.GptNeoXTest do
+  use ExUnit.Case, async: false
+
+  import Bumblebee.TestHelpers
+
+  @moduletag model_test_tags()
+
+  describe "integration" do
+    test "base model" do
+      assert {:ok, %{model: model, params: params, spec: spec}} =
+               Bumblebee.load_model({:hf, "seanmor5/tiny-gpt-neox-test"}, architecture: :base)
+
+      assert %Bumblebee.Text.GptNeoX{architecture: :base} = spec
+
+      input_ids = Nx.tensor([[4, 928, 219, 10, 591, 1023]])
+
+      inputs = %{
+        "input_ids" => input_ids
+      }
+
+      outputs = Axon.predict(model, params, inputs)
+
+      assert Nx.shape(outputs.hidden_state) == {1, 6, 32}
+
+      assert_all_close(
+        outputs.hidden_state[[.., 1..3, 1..3]],
+        Nx.tensor([
+          [[1.4331, 0.7042, -2.8534], [1.4009, 1.5367, -0.8567], [0.7013, 1.5902, -1.4052]]
+        ]),
+        atol: 1.0e-2
+      )
+    end
+
+    # test "sequence classification model" do
+    #   assert {:ok, %{model: model, params: params, spec: spec}} =
+    #            Bumblebee.load_model({:hf, "valhalla/bart-large-sst2"})
+
+    #   assert %Bumblebee.Text.Bart{architecture: :for_sequence_classification} = spec
+    #   input_ids = Nx.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 1588, 2]])
+
+    #   inputs = %{
+    #     "input_ids" => input_ids
+    #   }
+
+    #   outputs = Axon.predict(model, params, inputs)
+
+    #   assert Nx.shape(outputs.logits) == {1, 2}
+
+    #   assert_all_close(
+    #     outputs.logits,
+    #     Nx.tensor([[-0.1599, -0.0090]]),
+    #     atol: 1.0e-4
+    #   )
+    # end
+
+    test "causal language model" do
+      assert {:ok, %{model: model, params: params, spec: spec}} =
+               Bumblebee.load_model({:hf, "seanmor5/tiny-gpt-neox-test"},
+                 architecture: :for_causal_language_modeling
+               )
+
+      assert %Bumblebee.Text.GptNeoX{architecture: :for_causal_language_modeling} = spec
+
+      input_ids = Nx.tensor([[4, 928, 219, 10, 591, 1023]])
+
+      inputs = %{
+        "input_ids" => input_ids
+      }
+
+      outputs = Axon.predict(model, params, inputs)
+
+      assert Nx.shape(outputs.logits) == {1, 6, 1024}
+
+      assert_all_close(
+        outputs.logits[[.., 1..3, 1..3]],
+        Nx.tensor([
+          [[0.0559, 0.1583, 0.0423], [0.0446, 0.0843, -0.0328], [0.1069, 0.0430, 0.0127]]
+        ]),
+        atol: 1.0e-2
+      )
+    end
+  end
+end

--- a/test/bumblebee/text/gpt_neo_x_test.exs
+++ b/test/bumblebee/text/gpt_neo_x_test.exs
@@ -31,27 +31,53 @@ defmodule Bumblebee.Text.GptNeoXTest do
       )
     end
 
-    # test "sequence classification model" do
-    #   assert {:ok, %{model: model, params: params, spec: spec}} =
-    #            Bumblebee.load_model({:hf, "valhalla/bart-large-sst2"})
+    test "sequence classification model" do
+      assert {:ok, %{model: model, params: params, spec: spec}} =
+               Bumblebee.load_model(
+                 {:hf, "hf-internal-testing/tiny-random-GPTNeoXForSequenceClassification"}
+               )
 
-    #   assert %Bumblebee.Text.Bart{architecture: :for_sequence_classification} = spec
-    #   input_ids = Nx.tensor([[0, 345, 232, 328, 740, 140, 1695, 69, 6078, 1588, 2]])
+      assert %Bumblebee.Text.GptNeoX{architecture: :for_sequence_classification} = spec
+      input_ids = Nx.tensor([[4, 928, 219, 10, 591, 1023]])
 
-    #   inputs = %{
-    #     "input_ids" => input_ids
-    #   }
+      inputs = %{
+        "input_ids" => input_ids
+      }
 
-    #   outputs = Axon.predict(model, params, inputs)
+      outputs = Axon.predict(model, params, inputs)
 
-    #   assert Nx.shape(outputs.logits) == {1, 2}
+      assert Nx.shape(outputs.logits) == {1, 2}
 
-    #   assert_all_close(
-    #     outputs.logits,
-    #     Nx.tensor([[-0.1599, -0.0090]]),
-    #     atol: 1.0e-4
-    #   )
-    # end
+      assert_all_close(
+        outputs.logits,
+        Nx.tensor([[0.0622, -0.0701]]),
+        atol: 1.0e-4
+      )
+    end
+
+    test "token classification model" do
+      assert {:ok, %{model: model, params: params, spec: spec}} =
+               Bumblebee.load_model(
+                 {:hf, "hf-internal-testing/tiny-random-GPTNeoXForTokenClassification"}
+               )
+
+      assert %Bumblebee.Text.GptNeoX{architecture: :for_token_classification} = spec
+      input_ids = Nx.tensor([[4, 928, 219, 10, 591, 1023]])
+
+      inputs = %{
+        "input_ids" => input_ids
+      }
+
+      outputs = Axon.predict(model, params, inputs)
+
+      assert Nx.shape(outputs.logits) == {1, 6, 2}
+
+      assert_all_close(
+        outputs.logits[[.., 1..3]],
+        Nx.tensor([[[0.0089, -0.0230], [-0.0282, 0.0478], [0.1127, -0.0674]]]),
+        atol: 1.0e-4
+      )
+    end
 
     test "causal language model" do
       assert {:ok, %{model: model, params: params, spec: spec}} =


### PR DESCRIPTION
Should support StableLM. It's rebased off of Llama for rotary embeddings.

@jonatanklosko I wonder if you might be able to take a look at the sliced qkv calculation? When debugging the values I was getting for `query` are correct, but for `key` they are way off. 