### PR TITLE
Add support for `function_to_apply` in classification

### DIFF
--- a/lib/bumblebee/shared.ex
+++ b/lib/bumblebee/shared.ex
@@ -323,6 +323,29 @@ defmodule Bumblebee.Shared do
   end
 
   @doc """
+  Converts the logits to scores as per the given scores function.
+
+  Raises `ArgumentError` if the scores function is invalid.
+  """
+  @spec logits_to_scores(Nx.Tensor.t(), atom()) :: Nx.Tensor.t()
+  def logits_to_scores(logits, scores_function) do
+    case scores_function do
+      :softmax ->
+        Axon.Activations.softmax(logits)
+
+      :sigmoid ->
+        Axon.Activations.sigmoid(logits)
+
+      :none ->
+        logits
+
+      other ->
+        raise ArgumentError,
+              "expected :scores_function to be either of :softmax, :sigmoid or :none, got: #{inspect(other)}"
+    end
+  end
+
+  @doc """
   Generates tokenizer implementation.
   """
   defmacro tokenizer_impl(opts) do

--- a/lib/bumblebee/shared.ex
+++ b/lib/bumblebee/shared.ex
@@ -323,7 +323,7 @@ defmodule Bumblebee.Shared do
   end
 
   @doc """
-  Converts the logits to scores as per the given scores function.
+  Converts logits to scores as per the given scores function.
 
   Raises `ArgumentError` if the scores function is invalid.
   """

--- a/lib/bumblebee/text.ex
+++ b/lib/bumblebee/text.ex
@@ -82,6 +82,10 @@ defmodule Bumblebee.Text do
       a defn compiler using `:defn_options` to maximally reduce inference
       time.
 
+    * `:scores_function` - the function to use for converting logits to
+      scores. Should be one of `:softmax`, `:sigmoid`, or `:none`.
+      Defaults to `:softmax`
+
     * `:defn_options` - the options for JIT compilation. Defaults to `[]`
 
   ## Examples
@@ -268,6 +272,10 @@ defmodule Bumblebee.Text do
       It is advised to set this option in production and also configure
       a defn compiler using `:defn_options` to maximally reduce inference
       time.
+
+    * `:scores_function` - the function to use for converting logits to
+      scores. Should be one of `:softmax`, `:sigmoid`, or `:none`.
+      Defaults to `:softmax`
 
     * `:defn_options` - the options for JIT compilation. Defaults to `[]`
 

--- a/lib/bumblebee/text/text_classification.ex
+++ b/lib/bumblebee/text/text_classification.ex
@@ -8,11 +8,11 @@ defmodule Bumblebee.Text.TextClassification do
     Shared.validate_architecture!(spec, :for_sequence_classification)
 
     opts =
-      Keyword.validate!(opts, [:compile, top_k: 5, function_to_apply: "softmax", defn_options: []])
+      Keyword.validate!(opts, [:compile, top_k: 5, scores_function: "softmax", defn_options: []])
 
     top_k = opts[:top_k]
     compile = opts[:compile]
-    function_to_apply = opts[:function_to_apply]
+    scores_function = opts[:scores_function]
     defn_options = opts[:defn_options]
 
     batch_size = compile[:batch_size]
@@ -27,21 +27,7 @@ defmodule Bumblebee.Text.TextClassification do
 
     scores_fun = fn params, input ->
       outputs = predict_fun.(params, input)
-
-      case function_to_apply do
-        "softmax" ->
-          Axon.Activations.softmax(outputs.logits)
-
-        "sigmoid" ->
-          Axon.Activations.sigmoid(outputs.logits)
-
-        "none" ->
-          outputs.logits
-
-        _ ->
-          raise ArgumentError,
-                "Invalid :function_to_apply option. Only 'softmax', 'sigmoid', and 'none' are accepted"
-      end
+      Shared.logits_to_scores(outputs.logits, scores_function)
     end
 
     Nx.Serving.new(

--- a/lib/bumblebee/text/text_classification.ex
+++ b/lib/bumblebee/text/text_classification.ex
@@ -8,7 +8,7 @@ defmodule Bumblebee.Text.TextClassification do
     Shared.validate_architecture!(spec, :for_sequence_classification)
 
     opts =
-      Keyword.validate!(opts, [:compile, top_k: 5, scores_function: "softmax", defn_options: []])
+      Keyword.validate!(opts, [:compile, top_k: 5, scores_function: :softmax, defn_options: []])
 
     top_k = opts[:top_k]
     compile = opts[:compile]

--- a/lib/bumblebee/text/token_classification.ex
+++ b/lib/bumblebee/text/token_classification.ex
@@ -12,7 +12,7 @@ defmodule Bumblebee.Text.TokenClassification do
       Keyword.validate!(opts, [
         :aggregation,
         :compile,
-        scores_function: "softmax",
+        scores_function: :softmax,
         ignored_labels: ["O"],
         defn_options: []
       ])

--- a/lib/bumblebee/vision.ex
+++ b/lib/bumblebee/vision.ex
@@ -44,6 +44,10 @@ defmodule Bumblebee.Vision do
       a defn compiler using `:defn_options` to maximally reduce inference
       time.
 
+    * `:scores_function` - the function to use for converting logits to
+      scores. Should be one of `:softmax`, `:sigmoid`, or `:none`.
+      Defaults to `:softmax`
+
     * `:defn_options` - the options for JIT compilation. Defaults to `[]`
 
   ## Examples

--- a/lib/bumblebee/vision/image_classification.ex
+++ b/lib/bumblebee/vision/image_classification.ex
@@ -12,7 +12,7 @@ defmodule Bumblebee.Vision.ImageClassification do
     ])
 
     opts =
-      Keyword.validate!(opts, [:compile, top_k: 5, scores_function: "softmax", defn_options: []])
+      Keyword.validate!(opts, [:compile, top_k: 5, scores_function: :softmax, defn_options: []])
 
     top_k = opts[:top_k]
     compile = opts[:compile]


### PR DESCRIPTION
For classification models, users should have some way of specifying the function to be applied to the logits rather than `softmax` always being used since the logits do not always correspond to mutually exclusive classes.

Take, for example, a model's logits representing whether a piece of text conveys negative, neutral, or positive sentiment in a text classification task. In this case, the `softmax` activation function is apt as it ensures that the probabilities in the final output vector sum to 1. However, if the logits denote whether the text is toxic, obscene, insulting, etc. (as seen in [Detoxify models](https://github.com/unitaryai/detoxify)), the `sigmoid` activation function would be more appropriate since the values in the final output vector do not necessarily have to sum to 1.

HF pipelines used `softmax` as the mandatory activation function over multi-class model logits until https://github.com/huggingface/transformers/pull/8328, when they added support for the `function_to_apply` parameter which can be specified by the user.

I am proposing support for a `function_to_apply` parameter here as well. The options are the same as implemented in HF: `softmax`, `sigmoid`, and `none` (`none` applies no activation function and just returns the raw logits). `softmax` is the default since it preserves backward compatibility and seems to be the most common case.