### PR TITLE
Add image embedding serving

### DIFF
--- a/lib/bumblebee/vision.ex
+++ b/lib/bumblebee/vision.ex
@@ -160,10 +160,6 @@ defmodule Bumblebee.Vision do
         * `:batch_size` - the maximum batch size of the input. Inputs
           are optionally padded to always match this batch size
 
-        * `:image_size` - the size of the input spatial dimensions
-
-        * `:channels` - the number of channels in the input
-
       It is advised to set this option in production and also configure
       a defn compiler using `:defn_options` to maximally reduce inference
       time.

--- a/lib/bumblebee/vision/image_embedding.ex
+++ b/lib/bumblebee/vision/image_embedding.ex
@@ -1,0 +1,94 @@
+defmodule Bumblebee.Vision.ImageEmbedding do
+  @moduledoc false
+
+  alias Bumblebee.Shared
+
+  def image_embedding(model_info, featurizer, opts \\ []) do
+    %{model: model, params: params, spec: _spec} = model_info
+
+    opts =
+      Keyword.validate!(opts, [
+        :compile,
+        output_attribute: :pooled_state,
+        embedding_processor: nil,
+        defn_options: []
+      ])
+
+    output_attribute = opts[:output_attribute]
+    embedding_processor = opts[:embedding_processor]
+    defn_options = opts[:defn_options]
+
+    compile =
+      if compile = opts[:compile] do
+        compile
+        |> Keyword.validate!([:batch_size, :num_channels, :image_size])
+        |> Shared.require_options!([:batch_size, :num_channels, :image_size])
+      end
+
+    batch_size = compile[:batch_size]
+    image_size = compile[:image_size]
+    num_channels = compile[:num_channels]
+
+    {_init_fun, encoder} = Axon.build(model)
+
+    embedding_fun = fn params, inputs ->
+      output = encoder.(params, inputs)
+
+      output =
+        if is_map(output) do
+          output[output_attribute]
+        else
+          output
+        end
+
+      output =
+        case embedding_processor do
+          nil ->
+            output
+
+          :l2_norm ->
+            Bumblebee.Utils.Nx.normalize(output)
+
+          other ->
+            raise ArgumentError,
+                  "expected :embedding_processor to be one of nil or :l2_norm, got: #{inspect(other)}"
+        end
+
+      output
+    end
+
+    Nx.Serving.new(
+      fn defn_options ->
+        embedding_fun =
+          Shared.compile_or_jit(embedding_fun, defn_options, compile != nil, fn ->
+            inputs = %{
+              "pixel_values" =>
+                Nx.template({batch_size, image_size, image_size, num_channels}, :f32)
+            }
+
+            [params, inputs]
+          end)
+
+        fn inputs ->
+          inputs = Shared.maybe_pad(inputs, batch_size)
+          embedding_fun.(params, inputs)
+        end
+      end,
+      defn_options
+    )
+    |> Nx.Serving.process_options(batch_size: batch_size)
+    |> Nx.Serving.client_preprocessing(fn input ->
+      {images, multi?} = Shared.validate_serving_input!(input, &Shared.validate_image/1)
+
+      inputs = Bumblebee.apply_featurizer(featurizer, images)
+
+      {Nx.Batch.concatenate([inputs]), multi?}
+    end)
+    |> Nx.Serving.client_postprocessing(fn {embeddings, _metadata}, multi? ->
+      for embedding <- Bumblebee.Utils.Nx.batch_to_list(embeddings) do
+        %{embedding: embedding}
+      end
+      |> Shared.normalize_output(multi?)
+    end)
+  end
+end

--- a/test/bumblebee/vision/image_embedding_test.exs
+++ b/test/bumblebee/vision/image_embedding_test.exs
@@ -52,28 +52,5 @@ defmodule Bumblebee.Vision.ImageEmbeddingTest do
         atol: 1.0e-4
       )
     end
-
-    test "returns ViT embedding for an image, using compile option" do
-      {:ok, model_info} = Bumblebee.load_model({:hf, "google/vit-base-patch16-224"})
-
-      {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "google/vit-base-patch16-224"})
-
-      options = [
-        output_attribute: :logits,
-        compile: [batch_size: 5]
-      ]
-
-      serving = Bumblebee.Vision.ImageEmbedding.image_embedding(model_info, featurizer, options)
-      image = StbImage.read_file!(Path.join(@images_dir, "coco/39769.jpeg"))
-
-      assert %{embedding: %Nx.Tensor{} = embedding} = Nx.Serving.run(serving, image)
-      assert Nx.shape(embedding) == {1000}
-
-      assert_all_close(
-        embedding[1..3],
-        Nx.tensor([0.8104, -0.0693, 0.4399]),
-        atol: 1.0e-4
-      )
-    end
   end
 end

--- a/test/bumblebee/vision/image_embedding_test.exs
+++ b/test/bumblebee/vision/image_embedding_test.exs
@@ -60,7 +60,7 @@ defmodule Bumblebee.Vision.ImageEmbeddingTest do
 
       options = [
         output_attribute: :logits,
-        compile: [batch_size: 5, image_size: 224, num_channels: 3]
+        compile: [batch_size: 5]
       ]
 
       serving = Bumblebee.Vision.ImageEmbedding.image_embedding(model_info, featurizer, options)

--- a/test/bumblebee/vision/image_embedding_test.exs
+++ b/test/bumblebee/vision/image_embedding_test.exs
@@ -1,0 +1,79 @@
+defmodule Bumblebee.Vision.ImageEmbeddingTest do
+  use ExUnit.Case, async: false
+
+  import Bumblebee.TestHelpers
+
+  @moduletag model_test_tags()
+  @images_dir Path.expand("../../fixtures/images", __DIR__)
+
+  describe "integration" do
+    test "returns CLIP Vision embedding (without projection head) for an image" do
+      {:ok, model_info} =
+        Bumblebee.load_model({:hf, "openai/clip-vit-base-patch32"},
+          module: Bumblebee.Vision.ClipVision
+        )
+
+      {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/clip-vit-base-patch32"})
+
+      serving = Bumblebee.Vision.ImageEmbedding.image_embedding(model_info, featurizer)
+      image = StbImage.read_file!(Path.join(@images_dir, "coco/39769.jpeg"))
+
+      assert %{embedding: %Nx.Tensor{} = embedding} = Nx.Serving.run(serving, image)
+      assert Nx.shape(embedding) == {768}
+
+      assert_all_close(
+        embedding[1..3],
+        Nx.tensor([0.0978, -0.7233, -0.7707]),
+        atol: 1.0e-4
+      )
+    end
+
+    test "returns normalized CLIP Vision embedding (without projection head) for an image" do
+      {:ok, model_info} =
+        Bumblebee.load_model({:hf, "openai/clip-vit-base-patch32"},
+          module: Bumblebee.Vision.ClipVision
+        )
+
+      {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/clip-vit-base-patch32"})
+
+      options = [
+        embedding_processor: :l2_norm
+      ]
+
+      serving = Bumblebee.Vision.ImageEmbedding.image_embedding(model_info, featurizer, options)
+      image = StbImage.read_file!(Path.join(@images_dir, "coco/39769.jpeg"))
+
+      assert %{embedding: %Nx.Tensor{} = embedding} = Nx.Serving.run(serving, image)
+      assert Nx.shape(embedding) == {768}
+
+      assert_all_close(
+        embedding[1..3],
+        Nx.tensor([0.0036, -0.0269, -0.0286]),
+        atol: 1.0e-4
+      )
+    end
+
+    test "returns ViT embedding for an image, using compile option" do
+      {:ok, model_info} = Bumblebee.load_model({:hf, "google/vit-base-patch16-224"})
+
+      {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "google/vit-base-patch16-224"})
+
+      options = [
+        output_attribute: :logits,
+        compile: [batch_size: 5, image_size: 224, num_channels: 3]
+      ]
+
+      serving = Bumblebee.Vision.ImageEmbedding.image_embedding(model_info, featurizer, options)
+      image = StbImage.read_file!(Path.join(@images_dir, "coco/39769.jpeg"))
+
+      assert %{embedding: %Nx.Tensor{} = embedding} = Nx.Serving.run(serving, image)
+      assert Nx.shape(embedding) == {1000}
+
+      assert_all_close(
+        embedding[1..3],
+        Nx.tensor([0.8104, -0.0693, 0.4399]),
+        atol: 1.0e-4
+      )
+    end
+  end
+end


### PR DESCRIPTION
- Adds a serving for extracting embeddings from an image using Vision models like clip, blip, vit, deit.
- Supports L2 Normalization of the output embedding via `embedding_processor` attribute, similar to `TextEmbedding`. 
