### PR TITLE
Add support for streaming speech-to-text results

### DIFF
--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -284,9 +284,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     state = %{state | lengths: lengths_rest}
 
     acc =
-      outputs
-      |> Enum.zip(lengths)
-      |> Enum.reduce(state.acc, fn {sequence, lengths}, acc ->
+      Enum.zip_reduce([outputs, lengths], state.acc, fn [sequence, lengths], acc ->
         process_output(
           sequence,
           lengths,

--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -483,6 +483,8 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     # above, we would use the second alignment, taking `abc` from the
     # left sequence and `de` from the right one.
 
+    # We use binary backend so we are not blocked by the serving computation,
+    # in this case we do simple operations with small data so it is fine
     sequences = Enum.map(sequences, &Nx.tensor(&1, backend: Nx.BinaryBackend))
 
     {[left_sequence], right_sequences} = Enum.split(sequences, 1)

--- a/lib/bumblebee/text/generation.ex
+++ b/lib/bumblebee/text/generation.ex
@@ -948,7 +948,7 @@ defmodule Bumblebee.Text.Generation do
               {[], state}
           end
 
-        {:done, _, _}, state ->
+        {:batch, _, _}, state ->
           chunk = pending_chunk(tokenizer, state)
 
           if chunk == "" do

--- a/lib/bumblebee/text/generation.ex
+++ b/lib/bumblebee/text/generation.ex
@@ -891,17 +891,18 @@ defmodule Bumblebee.Text.Generation do
 
       {batch, multi?}
     end)
-    |> Nx.Serving.client_postprocessing(fn {token_ids, _metadata}, multi? ->
+    |> maybe_stream(opts[:stream], tokenizer)
+  end
+
+  defp maybe_stream(serving, false, tokenizer) do
+    Nx.Serving.client_postprocessing(serving, fn {token_ids, _metadata}, multi? ->
       decoded = Bumblebee.Tokenizer.decode(tokenizer, token_ids)
 
       decoded
       |> Enum.map(&%{results: [%{text: &1}]})
       |> Shared.normalize_output(multi?)
     end)
-    |> maybe_stream(opts[:stream], tokenizer)
   end
-
-  defp maybe_stream(serving, false, _tokenizer), do: serving
 
   defp maybe_stream(serving, true, tokenizer) do
     serving

--- a/test/bumblebee/audio/speech_to_text_whisper_test.exs
+++ b/test/bumblebee/audio/speech_to_text_whisper_test.exs
@@ -147,5 +147,113 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
                ]
              }
     end
+
+    test "streaming without timestamps" do
+      {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
+      {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
+      {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
+      {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+
+      serving =
+        Bumblebee.Audio.speech_to_text_whisper(
+          model_info,
+          featurizer,
+          tokenizer,
+          generation_config,
+          chunk_num_seconds: 30,
+          defn_options: [compiler: EXLA],
+          stream: true
+        )
+
+      audio =
+        Path.join(@audio_dir, "librivox/46s_pcm_f32le_16000.bin")
+        |> File.read!()
+        |> Nx.from_binary(:f32)
+
+      stream = Nx.Serving.run(serving, audio)
+
+      assert Enum.to_list(stream) == [
+               %{
+                 text:
+                   " An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonja. An awakening by Alice Pirlong. O spring will wake in the heart of me with the rapture of blown violets, when the green bud quickens on every tree to spring will wake in the heart of me, and queues of honey",
+                 start_timestamp_seconds: nil,
+                 end_timestamp_seconds: nil
+               },
+               %{
+                 text:
+                   " will reign on the lee, tangling the grasses in silver nets. Yes, spring will awaken the heart of me with the rapture of blown violets. End of an awakening, this recording is in the public domain.",
+                 start_timestamp_seconds: nil,
+                 end_timestamp_seconds: nil
+               }
+             ]
+    end
+
+    test "streaming with timestamps" do
+      {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
+      {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
+      {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
+      {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+
+      serving =
+        Bumblebee.Audio.speech_to_text_whisper(
+          model_info,
+          featurizer,
+          tokenizer,
+          generation_config,
+          chunk_num_seconds: 30,
+          defn_options: [compiler: EXLA],
+          timestamps: :segments,
+          stream: true
+        )
+
+      audio =
+        Path.join(@audio_dir, "librivox/46s_pcm_f32le_16000.bin")
+        |> File.read!()
+        |> Nx.from_binary(:f32)
+
+      stream = Nx.Serving.run(serving, audio)
+
+      assert Enum.to_list(stream) == [
+               %{
+                 text:
+                   " An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonia.",
+                 start_timestamp_seconds: 0.0,
+                 end_timestamp_seconds: 7.0
+               },
+               %{
+                 text: " An awakening by Alice Pirlong.",
+                 start_timestamp_seconds: 7.0,
+                 end_timestamp_seconds: 11.0
+               },
+               %{
+                 text:
+                   " O spring will wake in the heart of me with the rapture of blown violets, when the green bud",
+                 start_timestamp_seconds: 11.0,
+                 end_timestamp_seconds: 18.12
+               },
+               %{
+                 text:
+                   " quickens on every tree to spring will wake in the heart of me, and queues of honey will reign on the lee,",
+                 start_timestamp_seconds: 18.12,
+                 end_timestamp_seconds: 25.92
+               },
+               %{
+                 text:
+                   " tangling the grasses in silver nets. Yes, spring will awaken the heart of me",
+                 start_timestamp_seconds: 25.92,
+                 end_timestamp_seconds: 32.48
+               },
+               %{
+                 text: " with the rapture of blown violets.",
+                 start_timestamp_seconds: 32.48,
+                 end_timestamp_seconds: 34.88
+               },
+               %{
+                 text: " End of an awakening, this recording is in the public domain.",
+                 start_timestamp_seconds: 36.96,
+                 end_timestamp_seconds: 40.72
+               }
+             ]
+    end
   end
 end

--- a/test/bumblebee/audio/speech_to_text_whisper_test.exs
+++ b/test/bumblebee/audio/speech_to_text_whisper_test.exs
@@ -31,7 +31,15 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         |> File.read!()
         |> Nx.from_binary(:f32)
 
-      assert %{results: [%{text: "Tower of strength."}]} = Nx.Serving.run(serving, audio)
+      assert Nx.Serving.run(serving, audio) == %{
+               chunks: [
+                 %{
+                   text: " Tower of strength.",
+                   start_timestamp_seconds: nil,
+                   end_timestamp_seconds: nil
+                 }
+               ]
+             }
     end
 
     test "long-form transcription with chunking" do
@@ -55,10 +63,22 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         |> File.read!()
         |> Nx.from_binary(:f32)
 
-      transcription =
-        "An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonja. An awakening by Alice Pirlong. O spring will wake in the heart of me with the rapture of blown violets, when the green bud quickens on every tree to spring will wake in the heart of me, and queues of honey will reign on the lee, tangling the grasses in silver nets. Yes, spring will awaken the heart of me with the rapture of blown violets. End of an awakening, this recording is in the public domain."
-
-      assert %{results: [%{text: ^transcription}]} = Nx.Serving.run(serving, audio)
+      assert Nx.Serving.run(serving, audio) == %{
+               chunks: [
+                 %{
+                   text:
+                     " An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonja. An awakening by Alice Pirlong. O spring will wake in the heart of me with the rapture of blown violets, when the green bud quickens on every tree to spring will wake in the heart of me, and queues of honey",
+                   start_timestamp_seconds: nil,
+                   end_timestamp_seconds: nil
+                 },
+                 %{
+                   text:
+                     " will reign on the lee, tangling the grasses in silver nets. Yes, spring will awaken the heart of me with the rapture of blown violets. End of an awakening, this recording is in the public domain.",
+                   start_timestamp_seconds: nil,
+                   end_timestamp_seconds: nil
+                 }
+               ]
+             }
     end
 
     test "long-form transcription with timestamps" do
@@ -83,53 +103,49 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         |> File.read!()
         |> Nx.from_binary(:f32)
 
-      transcription =
-        "An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonia. An awakening by Alice Pirlong. O spring will wake in the heart of me with the rapture of blown violets, when the green bud quickens on every tree to spring will wake in the heart of me, and queues of honey will reign on the lee, tangling the grasses in silver nets. Yes, spring will awaken the heart of me with the rapture of blown violets. End of an awakening, this recording is in the public domain."
-
-      assert %{results: [%{text: ^transcription, chunks: chunks}]} =
-               Nx.Serving.run(serving, audio)
-
-      assert chunks == [
-               %{
-                 text:
-                   " An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonia.",
-                 start_timestamp_seconds: 0.0,
-                 end_timestamp_seconds: 7.0
-               },
-               %{
-                 text: " An awakening by Alice Pirlong.",
-                 start_timestamp_seconds: 7.0,
-                 end_timestamp_seconds: 11.0
-               },
-               %{
-                 text:
-                   " O spring will wake in the heart of me with the rapture of blown violets, when the green bud",
-                 start_timestamp_seconds: 11.0,
-                 end_timestamp_seconds: 18.12
-               },
-               %{
-                 text:
-                   " quickens on every tree to spring will wake in the heart of me, and queues of honey will reign on the lee,",
-                 start_timestamp_seconds: 18.12,
-                 end_timestamp_seconds: 25.92
-               },
-               %{
-                 text:
-                   " tangling the grasses in silver nets. Yes, spring will awaken the heart of me",
-                 start_timestamp_seconds: 25.92,
-                 end_timestamp_seconds: 32.48
-               },
-               %{
-                 text: " with the rapture of blown violets.",
-                 start_timestamp_seconds: 32.48,
-                 end_timestamp_seconds: 34.88
-               },
-               %{
-                 text: " End of an awakening, this recording is in the public domain.",
-                 start_timestamp_seconds: 36.96,
-                 end_timestamp_seconds: 40.72
-               }
-             ]
+      assert Nx.Serving.run(serving, audio) == %{
+               chunks: [
+                 %{
+                   text:
+                     " An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonia.",
+                   start_timestamp_seconds: 0.0,
+                   end_timestamp_seconds: 7.0
+                 },
+                 %{
+                   text: " An awakening by Alice Pirlong.",
+                   start_timestamp_seconds: 7.0,
+                   end_timestamp_seconds: 11.0
+                 },
+                 %{
+                   text:
+                     " O spring will wake in the heart of me with the rapture of blown violets, when the green bud",
+                   start_timestamp_seconds: 11.0,
+                   end_timestamp_seconds: 18.12
+                 },
+                 %{
+                   text:
+                     " quickens on every tree to spring will wake in the heart of me, and queues of honey will reign on the lee,",
+                   start_timestamp_seconds: 18.12,
+                   end_timestamp_seconds: 25.92
+                 },
+                 %{
+                   text:
+                     " tangling the grasses in silver nets. Yes, spring will awaken the heart of me",
+                   start_timestamp_seconds: 25.92,
+                   end_timestamp_seconds: 32.48
+                 },
+                 %{
+                   text: " with the rapture of blown violets.",
+                   start_timestamp_seconds: 32.48,
+                   end_timestamp_seconds: 34.88
+                 },
+                 %{
+                   text: " End of an awakening, this recording is in the public domain.",
+                   start_timestamp_seconds: 36.96,
+                   end_timestamp_seconds: 40.72
+                 }
+               ]
+             }
     end
   end
 end


### PR DESCRIPTION
Large audio is split into multiple chunks, now we support `stream: true`, so that output chunks are emitted as soon as they are available.