### PR TITLE
Add op-name to rms norm

### DIFF
--- a/lib/bumblebee/layers.ex
+++ b/lib/bumblebee/layers.ex
@@ -948,7 +948,11 @@ defmodule Bumblebee.Layers do
         initializer: opts[:initializer]
       )
 
-    Axon.layer(&rms_norm_impl/3, [input, weight], name: opts[:name], epsilon: opts[:epsilon], op_name: :rms_norm)
+    Axon.layer(&rms_norm_impl/3, [input, weight],
+      name: opts[:name],
+      epsilon: opts[:epsilon],
+      op_name: :rms_norm
+    )
   end
 
   defnp rms_norm_impl(input, weight, opts \\ []) do

--- a/lib/bumblebee/layers.ex
+++ b/lib/bumblebee/layers.ex
@@ -948,7 +948,7 @@ defmodule Bumblebee.Layers do
         initializer: opts[:initializer]
       )
 
-    Axon.layer(&rms_norm_impl/3, [input, weight], name: opts[:name], epsilon: opts[:epsilon])
+    Axon.layer(&rms_norm_impl/3, [input, weight], name: opts[:name], epsilon: opts[:epsilon], op_name: :rms_norm)
   end
 
   defnp rms_norm_impl(input, weight, opts \\ []) do


### PR DESCRIPTION
Partially to resolve https://github.com/elixir-nx/axon/issues/544

Llama specifically computes RMS norm in f32 always (this is probably the case with other models). The way to reflect this in an Axon mixed precision policy is to apply the policy with a modifier `except: [:rms_norm]` and it will apply it to all layers by op_name that match that. So we need rms norm here to have an op-name