### PR TITLE
Apply cross attention spec unet

### DIFF
--- a/lib/bumblebee/diffusion/unet_2d_conditional.ex
+++ b/lib/bumblebee/diffusion/unet_2d_conditional.ex
@@ -78,7 +78,8 @@ defmodule Bumblebee.Diffusion.UNet2DConditional do
     ],
     cross_attention_size: [
       default: 1280,
-      doc: "the dimensionality of the cross attention features (required if apply_cross_attention is true)"
+      doc:
+        "the dimensionality of the cross attention features (required if apply_cross_attention is true)"
     ],
     use_linear_projection: [
       default: false,
@@ -156,7 +157,10 @@ defmodule Bumblebee.Diffusion.UNet2DConditional do
 
     if spec.apply_cross_attention do
       encoder_hidden_state_shape = {1, 1, spec.cross_attention_size}
-      Map.merge(template, %{"encoder_hidden_state" => Nx.template(encoder_hidden_state_shape, :f32)})
+
+      Map.merge(template, %{
+        "encoder_hidden_state" => Nx.template(encoder_hidden_state_shape, :f32)
+      })
     else
       template
     end


### PR DESCRIPTION
Warning beginner 😋.

I have been trying to use the `UNet2DConditional` model but without cross attention (so basically a `UNet2D` model). 

In python, hugging face have both: [UNet2DCondition](https://huggingface.co/docs/diffusers/api/models/unet2d-cond) and [UNet2D](https://huggingface.co/docs/diffusers/api/models/unet2d).

I need to use an equivalent of `UNet2D`. Seems that it's supported by bumblebee for example in the unet layer in `down_block_2d` there is this doc: 

> When `encoder_hidden_state` is not `nil`, applies cross-attention.

However, from the `UNet2DConditional` model we have no way to have a nil `encoder_hidden_state`. So this PR add an option the model.

I'm not sure this won't bring confusion because from my understanding, without `encoder_hidden_state` this is not a conditional unet anymore.

Let me know what you think.

