### PR TITLE
Automatically detect diffusers params files

### DIFF
--- a/lib/bumblebee/diffusion/stable_diffusion.ex
+++ b/lib/bumblebee/diffusion/stable_diffusion.ex
@@ -75,20 +75,9 @@ defmodule Bumblebee.Diffusion.StableDiffusion do
       repository_id = "CompVis/stable-diffusion-v1-4"
 
       {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/clip-vit-large-patch14"})
-
       {:ok, clip} = Bumblebee.load_model({:hf, repository_id, subdir: "text_encoder"})
-
-      {:ok, unet} =
-        Bumblebee.load_model({:hf, repository_id, subdir: "unet"},
-          params_filename: "diffusion_pytorch_model.bin"
-        )
-
-      {:ok, vae} =
-        Bumblebee.load_model({:hf, repository_id, subdir: "vae"},
-          architecture: :decoder,
-          params_filename: "diffusion_pytorch_model.bin"
-        )
-
+      {:ok, unet} = Bumblebee.load_model({:hf, repository_id, subdir: "unet"})
+      {:ok, vae} = Bumblebee.load_model({:hf, repository_id, subdir: "vae"}, architecture: :decoder)
       {:ok, scheduler} = Bumblebee.load_scheduler({:hf, repository_id, subdir: "scheduler"})
       {:ok, featurizer} = Bumblebee.load_featurizer({:hf, repository_id, subdir: "feature_extractor"})
       {:ok, safety_checker} = Bumblebee.load_model({:hf, repository_id, subdir: "safety_checker"})

--- a/notebooks/stable_diffusion.livemd
+++ b/notebooks/stable_diffusion.livemd
@@ -29,20 +29,9 @@ Stable Diffusion is composed of several separate models and preprocessors, so we
 repository_id = "CompVis/stable-diffusion-v1-4"
 
 {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/clip-vit-large-patch14"})
-
 {:ok, clip} = Bumblebee.load_model({:hf, repository_id, subdir: "text_encoder"})
-
-{:ok, unet} =
-  Bumblebee.load_model({:hf, repository_id, subdir: "unet"},
-    params_filename: "diffusion_pytorch_model.bin"
-  )
-
-{:ok, vae} =
-  Bumblebee.load_model({:hf, repository_id, subdir: "vae"},
-    architecture: :decoder,
-    params_filename: "diffusion_pytorch_model.bin"
-  )
-
+{:ok, unet} = Bumblebee.load_model({:hf, repository_id, subdir: "unet"})
+{:ok, vae} = Bumblebee.load_model({:hf, repository_id, subdir: "vae"}, architecture: :decoder)
 {:ok, scheduler} = Bumblebee.load_scheduler({:hf, repository_id, subdir: "scheduler"})
 {:ok, featurizer} = Bumblebee.load_featurizer({:hf, repository_id, subdir: "feature_extractor"})
 {:ok, safety_checker} = Bumblebee.load_model({:hf, repository_id, subdir: "safety_checker"})

--- a/test/bumblebee/diffusion/stable_diffusion_test.exs
+++ b/test/bumblebee/diffusion/stable_diffusion_test.exs
@@ -15,19 +15,11 @@ defmodule Bumblebee.Diffusion.StableDiffusionTest do
       repository_id = "bumblebee-testing/tiny-stable-diffusion"
 
       {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/clip-vit-large-patch14"})
-
       {:ok, clip} = Bumblebee.load_model({:hf, repository_id, subdir: "text_encoder"})
-
-      {:ok, unet} =
-        Bumblebee.load_model({:hf, repository_id, subdir: "unet"},
-          params_filename: "diffusion_pytorch_model.bin"
-        )
+      {:ok, unet} = Bumblebee.load_model({:hf, repository_id, subdir: "unet"})
 
       {:ok, vae} =
-        Bumblebee.load_model({:hf, repository_id, subdir: "vae"},
-          architecture: :decoder,
-          params_filename: "diffusion_pytorch_model.bin"
-        )
+        Bumblebee.load_model({:hf, repository_id, subdir: "vae"}, architecture: :decoder)
 
       {:ok, scheduler} = Bumblebee.load_scheduler({:hf, repository_id, subdir: "scheduler"})
 

--- a/test/bumblebee/diffusion/unet_2d_conditional_test.exs
+++ b/test/bumblebee/diffusion/unet_2d_conditional_test.exs
@@ -8,8 +8,7 @@ defmodule Bumblebee.Diffusion.UNet2DConditionalTest do
   test ":base" do
     assert {:ok, %{model: model, params: params, spec: spec}} =
              Bumblebee.load_model(
-               {:hf, "hf-internal-testing/tiny-stable-diffusion-torch", subdir: "unet"},
-               params_filename: "diffusion_pytorch_model.bin"
+               {:hf, "hf-internal-testing/tiny-stable-diffusion-torch", subdir: "unet"}
              )
 
     assert %Bumblebee.Diffusion.UNet2DConditional{architecture: :base} = spec

--- a/test/bumblebee/diffusion/vae_kl_test.exs
+++ b/test/bumblebee/diffusion/vae_kl_test.exs
@@ -8,8 +8,7 @@ defmodule Bumblebee.Diffusion.VaeKlTest do
   test ":base" do
     assert {:ok, %{model: model, params: params, spec: spec}} =
              Bumblebee.load_model(
-               {:hf, "hf-internal-testing/tiny-stable-diffusion-torch", subdir: "vae"},
-               params_filename: "diffusion_pytorch_model.bin"
+               {:hf, "hf-internal-testing/tiny-stable-diffusion-torch", subdir: "vae"}
              )
 
     assert %Bumblebee.Diffusion.VaeKl{architecture: :base} = spec
@@ -39,8 +38,7 @@ defmodule Bumblebee.Diffusion.VaeKlTest do
     assert {:ok, %{model: model, params: params, spec: spec}} =
              Bumblebee.load_model(
                {:hf, "hf-internal-testing/tiny-stable-diffusion-torch", subdir: "vae"},
-               architecture: :decoder,
-               params_filename: "diffusion_pytorch_model.bin"
+               architecture: :decoder
              )
 
     assert %Bumblebee.Diffusion.VaeKl{architecture: :decoder} = spec
@@ -70,8 +68,7 @@ defmodule Bumblebee.Diffusion.VaeKlTest do
     assert {:ok, %{model: model, params: params, spec: spec}} =
              Bumblebee.load_model(
                {:hf, "hf-internal-testing/tiny-stable-diffusion-torch", subdir: "vae"},
-               architecture: :encoder,
-               params_filename: "diffusion_pytorch_model.bin"
+               architecture: :encoder
              )
 
     assert %Bumblebee.Diffusion.VaeKl{architecture: :encoder} = spec


### PR DESCRIPTION
We now have a listing with all filenames, so we can automatically detect the common files, like `diffusion_pytorch_model.bin` used by hf/diffusers. This simplifies loading for the end user :)