### PR TITLE
Return only new text from text generation

### DIFF
--- a/test/bumblebee/text/bart_test.exs
+++ b/test/bumblebee/text/bart_test.exs
@@ -157,6 +157,6 @@ defmodule Bumblebee.Text.BartTest do
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
     token_ids = generate.(params, inputs)
 
-    assert_equal(token_ids, Nx.tensor([[2, 988, 988, 988]]))
+    assert_equal(token_ids, Nx.tensor([[988, 988, 988]]))
   end
 end

--- a/test/bumblebee/text/blenderbot_test.exs
+++ b/test/bumblebee/text/blenderbot_test.exs
@@ -82,6 +82,6 @@ defmodule Bumblebee.Text.BlenderbotTest do
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
     token_ids = generate.(params, inputs)
 
-    assert_equal(token_ids, Nx.tensor([[1, 382, 382, 382]]))
+    assert_equal(token_ids, Nx.tensor([[382, 382, 382]]))
   end
 end

--- a/test/bumblebee/text/generation_test.exs
+++ b/test/bumblebee/text/generation_test.exs
@@ -38,9 +38,9 @@ defmodule Bumblebee.Text.GenerationTest do
     serving = Bumblebee.Text.generation(model_info, tokenizer, generation_config)
 
     # Without :no_repeat_ngram_length we get
-    # %{results: [%{text: "I was going to say, 'Well, I'm going to say,"}]}
+    # %{results: [%{text: " to say, 'Well, I'm going to say,"}]}
 
-    assert %{results: [%{text: "I was going to say, 'Well, I'm going back to the"}]} =
+    assert %{results: [%{text: " to say, 'Well, I'm going back to the"}]} =
              Nx.Serving.run(serving, "I was going")
   end
 
@@ -60,11 +60,8 @@ defmodule Bumblebee.Text.GenerationTest do
     # Note that this is just a snapshot test, we do not use any
     # reference value, because of PRNG difference
 
-    assert %{
-             results: [
-               %{text: "I was going to fall asleep.\"\n\nThis is not Wallace's fifth"}
-             ]
-           } = Nx.Serving.run(serving, "I was going")
+    assert %{results: [%{text: " to fall asleep.\"\n\nThis is not Wallace's fifth"}]} =
+             Nx.Serving.run(serving, "I was going")
   end
 
   test "contrastive search" do
@@ -80,7 +77,7 @@ defmodule Bumblebee.Text.GenerationTest do
 
     serving = Bumblebee.Text.generation(model_info, tokenizer, generation_config)
 
-    assert %{results: [%{text: "I was going to say, 'Well, I don't know what you"}]} =
+    assert %{results: [%{text: " to say, 'Well, I don't know what you"}]} =
              Nx.Serving.run(serving, "I was going")
   end
 

--- a/test/bumblebee/text/mbart_test.exs
+++ b/test/bumblebee/text/mbart_test.exs
@@ -155,6 +155,6 @@ defmodule Bumblebee.Text.MbartTest do
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
     token_ids = generate.(params, inputs)
 
-    assert_equal(token_ids, Nx.tensor([[0, 230_521, 20386, 20386]]))
+    assert_equal(token_ids, Nx.tensor([[230_521, 20386, 20386]]))
   end
 end

--- a/test/bumblebee/text/t5_test.exs
+++ b/test/bumblebee/text/t5_test.exs
@@ -167,7 +167,7 @@ defmodule Bumblebee.Text.T5Test do
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
     token_ids = generate.(params, inputs)
 
-    assert_equal(token_ids, Nx.tensor([[0, 0, 0, 0]]))
+    assert_equal(token_ids, Nx.tensor([[0, 0, 0]]))
   end
 
   test "generation with :for_conditional_generation without tied embeddings" do
@@ -195,6 +195,6 @@ defmodule Bumblebee.Text.T5Test do
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
     token_ids = generate.(params, inputs)
 
-    assert_equal(token_ids, Nx.tensor([[0, 6161, 29516, 9788]]))
+    assert_equal(token_ids, Nx.tensor([[6161, 29516, 9788]]))
   end
 end


### PR DESCRIPTION
Closes #247.

This changes text generation serving to only return the new text (without the prompt). This is consistent with streaming. Also, encoder-decoder models like BART already don't return the input text, since it is used as a "context" rather than a "prompt" to complete.

This is a small breaking change, but the next release is going to be 0.5.0 and I think it's fine.

Initially I thought about adding an option like `:return_full_text`, but to make it handle leading space in a generic way, we would need to make another tokenizer pass on the input, then prefix replace (that's what hf/transformers do). I don't think this is necessarily worth it, because the end user knows what model they work with, so they can easily concatenate the prompt, either adding a space or not. We can revisit the option if there is an actual use case, but it's usually the new text that users care about.