### PR TITLE
Make randomization seed a serving input, rather than compile option

### DIFF
--- a/lib/bumblebee/audio.ex
+++ b/lib/bumblebee/audio.ex
@@ -40,7 +40,10 @@ defmodule Bumblebee.Audio do
       requires `ffmpeg` installed)
 
   """
-  @type speech_to_text_whisper_input :: Nx.t() | {:file, String.t()}
+  @type audio :: Nx.t() | {:file, String.t()}
+
+  @type speech_to_text_whisper_input ::
+          audio() | %{:audio => audio(), optional(:seed) => integer()}
   @type speech_to_text_whisper_output :: %{
           chunks: list(speech_to_text_whisper_chunk())
         }
@@ -87,9 +90,6 @@ defmodule Bumblebee.Audio do
       annotated segment becomes an output chunk. Currently the only
       supported value is `:segments`, the length of each segment is up
       to the model
-
-    * `:seed` - random seed to use when sampling. By default the current
-      timestamp is used
 
     * `:compile` - compiles all computations for predefined input shapes
       during serving initialization. Should be a keyword list with the

--- a/lib/bumblebee/text.ex
+++ b/lib/bumblebee/text.ex
@@ -126,7 +126,8 @@ defmodule Bumblebee.Text do
   defdelegate token_classification(model_info, tokenizer, opts \\ []),
     to: Bumblebee.Text.TokenClassification
 
-  @type generation_input :: String.t()
+  @type generation_input ::
+          String.t() | %{:text => String.t(), optional(:seed) => integer()}
   @type generation_output :: %{results: list(generation_result())}
   @type generation_result :: %{text: String.t()}
 
@@ -137,9 +138,6 @@ defmodule Bumblebee.Text do
   A list of inputs is also supported.
 
   ## Options
-
-    * `:seed` - random seed to use when sampling. By default the current
-      timestamp is used
 
     * `:compile` - compiles all computations for predefined input shapes
       during serving initialization. Should be a keyword list with the
@@ -215,7 +213,11 @@ defmodule Bumblebee.Text do
   defdelegate generation(model_info, tokenizer, generation_config, opts \\ []),
     to: Bumblebee.Text.Generation
 
-  @type conversation_input :: %{text: String.t(), history: conversation_history() | nil}
+  @type conversation_input :: %{
+          :text => String.t(),
+          :history => conversation_history() | nil,
+          optional(:seed) => integer()
+        }
   @type conversation_output :: %{text: String.t(), history: conversation_history()}
 
   @type conversation_history :: list({:user | :generated, String.t()})
@@ -232,9 +234,6 @@ defmodule Bumblebee.Text do
   Note that either `:max_new_tokens` or `:max_length` must be specified.
 
   ## Options
-
-    * `:seed` - random seed to use when sampling. By default the current
-      timestamp is used
 
     * `:compile` - compiles all computations for predefined input shapes
       during serving initialization. Should be a keyword list with the

--- a/lib/bumblebee/vision.ex
+++ b/lib/bumblebee/vision.ex
@@ -86,7 +86,7 @@ defmodule Bumblebee.Vision do
   defdelegate image_classification(model_info, featurizer, opts \\ []),
     to: Bumblebee.Vision.ImageClassification
 
-  @type image_to_text_input :: image()
+  @type image_to_text_input :: image() | %{:image => image(), optional(:seed) => integer()}
   @type image_to_text_output :: %{results: list(image_to_text_result())}
   @type image_to_text_result :: %{text: String.t()}
 
@@ -97,9 +97,6 @@ defmodule Bumblebee.Vision do
   `t:image_to_text_output/0`. A list of inputs is also supported.
 
   ## Options
-
-    * `:seed` - random seed to use when sampling. By default the current
-      timestamp is used
 
     * `:compile` - compiles all computations for predefined input shapes
       during serving initialization. Should be a keyword list with the

--- a/lib/bumblebee/vision/image_to_text.ex
+++ b/lib/bumblebee/vision/image_to_text.ex
@@ -11,7 +11,7 @@ defmodule Bumblebee.Vision.ImageToText do
         %Text.GenerationConfig{} = generation_config,
         opts \\ []
       ) do
-    opts = Keyword.validate!(opts, [:seed, :compile, defn_options: [], preallocate_params: false])
+    opts = Keyword.validate!(opts, [:compile, defn_options: [], preallocate_params: false])
 
     %{model: model, params: params, spec: spec} = model_info
 
@@ -29,11 +29,11 @@ defmodule Bumblebee.Vision.ImageToText do
 
     batch_size = compile[:batch_size]
 
-    generate_fun =
-      Text.Generation.build_generate(model, spec, generation_config, Keyword.take(opts, [:seed]))
+    generate_fun = Text.Generation.build_generate(model, spec, generation_config)
 
-    generate_fun = fn params, inputs ->
+    generate_fun = fn params, {inputs, seed} ->
       inputs = Bumblebee.Featurizer.process_batch(featurizer, inputs)
+      inputs = Map.put(inputs, "seed", seed)
       generate_fun.(params, inputs)
     end
 
@@ -44,7 +44,8 @@ defmodule Bumblebee.Vision.ImageToText do
         generate_fun =
           Shared.compile_or_jit(generate_fun, defn_options, compile != nil, fn ->
             inputs = Bumblebee.Featurizer.batch_template(featurizer, batch_size)
-            [params, inputs]
+            seed = Nx.template({batch_size}, :s64)
+            [params, {inputs, seed}]
           end)
 
         fn inputs ->
@@ -56,9 +57,13 @@ defmodule Bumblebee.Vision.ImageToText do
     )
     |> Nx.Serving.batch_size(batch_size)
     |> Nx.Serving.client_preprocessing(fn input ->
-      {images, multi?} = Shared.validate_serving_input!(input, &Shared.validate_image/1)
+      {inputs, multi?} = Shared.validate_serving_input!(input, &validate_input/1)
+
+      images = Enum.map(inputs, & &1.image)
+      seed = Enum.map(inputs, & &1.seed) |> Nx.tensor(backend: Nx.BinaryBackend)
+
       inputs = Bumblebee.Featurizer.process_input(featurizer, images)
-      {Nx.Batch.concatenate([inputs]), multi?}
+      {Nx.Batch.concatenate([{inputs, seed}]), multi?}
     end)
     |> Nx.Serving.client_postprocessing(fn {token_ids, _metadata}, multi? ->
       decoded = Bumblebee.Tokenizer.decode(tokenizer, token_ids)
@@ -68,4 +73,14 @@ defmodule Bumblebee.Vision.ImageToText do
       |> Shared.normalize_output(multi?)
     end)
   end
+
+  defp validate_input(%{image: image} = input) do
+    if Shared.image?(image) do
+      {:ok, %{image: image, seed: input[:seed] || :erlang.system_time()}}
+    else
+      {:error, "expected an image, got: #{inspect(image)}"}
+    end
+  end
+
+  defp validate_input(input), do: validate_input(%{image: input})
 end

--- a/test/bumblebee/text/bart_test.exs
+++ b/test/bumblebee/text/bart_test.exs
@@ -149,7 +149,8 @@ defmodule Bumblebee.Text.BartTest do
 
     inputs = %{
       "input_ids" => Nx.tensor([[10, 20, 30, 40, 50, 60, 70, 80, 0, 0]]),
-      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]])
+      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]]),
+      "seed" => Nx.tensor([[0]])
     }
 
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)

--- a/test/bumblebee/text/blenderbot_test.exs
+++ b/test/bumblebee/text/blenderbot_test.exs
@@ -74,7 +74,8 @@ defmodule Bumblebee.Text.BlenderbotTest do
 
     inputs = %{
       "input_ids" => Nx.tensor([[10, 20, 30, 40, 50, 60, 70, 80, 0, 0]]),
-      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]])
+      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]]),
+      "seed" => Nx.tensor([[0]])
     }
 
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)

--- a/test/bumblebee/text/generation_test.exs
+++ b/test/bumblebee/text/generation_test.exs
@@ -55,13 +55,13 @@ defmodule Bumblebee.Text.GenerationTest do
         strategy: %{type: :multinomial_sampling}
       )
 
-    serving = Bumblebee.Text.generation(model_info, tokenizer, generation_config, seed: 0)
+    serving = Bumblebee.Text.generation(model_info, tokenizer, generation_config)
 
     # Note that this is just a snapshot test, we do not use any
     # reference value, because of PRNG difference
 
-    assert %{results: [%{text: " to fall asleep.\"\n\nThis is not Wallace's fifth"}]} =
-             Nx.Serving.run(serving, "I was going")
+    assert %{results: [%{text: " to give a speech to these execs. I don't"}]} =
+             Nx.Serving.run(serving, %{text: "I was going", seed: 0})
   end
 
   test "contrastive search" do

--- a/test/bumblebee/text/mbart_test.exs
+++ b/test/bumblebee/text/mbart_test.exs
@@ -147,7 +147,8 @@ defmodule Bumblebee.Text.MbartTest do
 
     inputs = %{
       "input_ids" => Nx.tensor([[10, 20, 30, 40, 50, 60, 70, 80, 0, 0]]),
-      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]])
+      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]]),
+      "seed" => Nx.tensor([[0]])
     }
 
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)

--- a/test/bumblebee/text/t5_test.exs
+++ b/test/bumblebee/text/t5_test.exs
@@ -159,7 +159,8 @@ defmodule Bumblebee.Text.T5Test do
 
     inputs = %{
       "input_ids" => Nx.tensor([[10, 20, 30, 40, 50, 60, 70, 80, 0, 0]]),
-      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]])
+      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]]),
+      "seed" => Nx.tensor([[0]])
     }
 
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)
@@ -187,7 +188,8 @@ defmodule Bumblebee.Text.T5Test do
 
     inputs = %{
       "input_ids" => Nx.tensor([[10, 20, 30, 40, 50, 60, 70, 80, 0, 0]]),
-      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]])
+      "attention_mask" => Nx.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 0, 0]]),
+      "seed" => Nx.tensor([[0]])
     }
 
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)


### PR DESCRIPTION
Closes #284.

Now we can do `Nx.Serving.run(serving, %{text: "...", seed: 0})` for text generation and similar for other servings.