### PR TITLE
Fix loading more recent VaeKl checkpoints

### DIFF
--- a/lib/bumblebee/diffusion/unet_2d_conditional.ex
+++ b/lib/bumblebee/diffusion/unet_2d_conditional.ex
@@ -407,6 +407,8 @@ defmodule Bumblebee.Diffusion.UNet2DConditional do
   end
 
   defimpl Bumblebee.HuggingFace.Transformers.Model do
+    alias Bumblebee.HuggingFace.Transformers
+
     def params_mapping(_spec) do
       block_mapping = %{
         "transformers.{m}.norm" => "attentions.{m}.norm",
@@ -449,10 +451,9 @@ defmodule Bumblebee.Diffusion.UNet2DConditional do
       }
 
       blocks_mapping =
-        for {target, source} <- block_mapping,
-            prefix <- ["down_blocks.{n}", "mid_block", "up_blocks.{n}"],
-            do: {prefix <> "." <> target, prefix <> "." <> source},
-            into: %{}
+        ["down_blocks.{n}", "mid_block", "up_blocks.{n}"]
+        |> Enum.map(&Transformers.Utils.prefix_params_mapping(block_mapping, &1, &1))
+        |> Enum.reduce(&Map.merge/2)
 
       %{
         "time_embedding.intermediate" => "time_embedding.linear_1",

--- a/lib/bumblebee/huggingface/transformers/model.ex
+++ b/lib/bumblebee/huggingface/transformers/model.ex
@@ -4,16 +4,17 @@ defprotocol Bumblebee.HuggingFace.Transformers.Model do
   # This protocol defines details related to loading Bumblebee model
   # from huggingface/transformers model.
 
-  @type params_mapping :: %{
-          layer_name() => layer_name() | params_source()
-        }
+  @type params_mapping :: %{layer_name() => params_source()}
 
-  @type params_source :: %{
-          param_name() =>
-            {list(source()), (list(Nx.tensor()) -> Nx.Tensor.t() | Nx.Container.t())}
-        }
+  @type params_source :: layer_name() | list(layer_name()) | param_builders()
 
-  @type source :: {layer_name(), param_name() | list(param_name())}
+  @type param_builders :: %{param_name() => param_builder()}
+
+  @type param_builder ::
+          {list(param_source()), (list(Nx.tensor()) -> Nx.Tensor.t() | Nx.Container.t())}
+
+  @type param_source :: param_ref() | list(param_ref())
+  @type param_ref :: {layer_name(), param_name()}
 
   @type layer_name :: String.t()
   @type param_name :: String.t()
@@ -53,8 +54,8 @@ defprotocol Bumblebee.HuggingFace.Transformers.Model do
   automatically.
 
   In some cases, particularly with model-specific layers/parameters,
-  we may need more control over the parameter mapping. In such cases, instead
-  of source layer name, a map with parameter-level transformations
+  we may need more control over the parameter mapping. In such cases,
+  instead of source layer name, a map with parameter-level transformations
   may be specified:
 
       %{
@@ -69,9 +70,10 @@ defprotocol Bumblebee.HuggingFace.Transformers.Model do
 
   For each parameter, we specify a list of source parameters in the
   form of `{source_layer_name, source_param_name}`, then a function
-  to build our parameter value. Multiple source parameter names to
-  try may be specified. With the explicit transformation we can
-  handle arbitrary parameter name and value transformations.
+  to build our parameter value. Instead of a single tuple, we can
+  specify a list of those to try one by one. With the explicit
+  transformation we can handle arbitrary parameter name and value
+  transformations.
   """
   @spec params_mapping(t()) :: params_mapping()
   def params_mapping(spec)


### PR DESCRIPTION
https://github.com/huggingface/diffusers/pull/3387 changed layer names in the VaeKl implementation, so in order to load newer and older checkpoints we need to check for both layer names. In particular this is relevant to fp16 checkpoints for SDv1-4.

I changed the params mapping to support multiple layer names to try like this:

```elixir
%{
  ...,
  "attentions.{m}.query" => ["attentions.{m}.to_q", "attentions.{m}.query"],
  ...
}
```