### PR TITLE
Add :type option to load model under specific precision

### DIFF
--- a/lib/bumblebee/conversion/pytorch.ex
+++ b/lib/bumblebee/conversion/pytorch.ex
@@ -145,6 +145,7 @@ defmodule Bumblebee.Conversion.PyTorch do
 
                 case verify_param_shape(param_expr, value) do
                   :ok ->
+                    value = ensure_type(param_expr, value)
                     {value, diff}
 
                   {:error, expected, actual} ->
@@ -484,6 +485,15 @@ defmodule Bumblebee.Conversion.PyTorch do
 
   defp expr_shape(expr) do
     Utils.Nx.map(expr, &Nx.shape/1)
+  end
+
+  defp ensure_type(param_expr, value) do
+    Utils.Nx.zip_with(param_expr, value, fn expr, tensor ->
+      case {Nx.type(expr), Nx.type(tensor)} do
+        {type, type} -> tensor
+        {expected, _actual} -> Nx.as_type(tensor, expected)
+      end
+    end)
   end
 
   defp unflatten_leading(tensor, axis_size) do

--- a/test/bumblebee_test.exs
+++ b/test/bumblebee_test.exs
@@ -63,5 +63,23 @@ defmodule BumblebeeTest do
                      )
                    end
     end
+
+    test "passing :type casts params accordingly" do
+      assert {:ok, %{params: params}} =
+               Bumblebee.load_model({:hf, "hf-internal-testing/tiny-random-GPT2Model"},
+                 type: :bf16
+               )
+
+      assert Nx.type(params["decoder.blocks.0.ffn.output"]["kernel"]) == {:bf, 16}
+      assert Nx.type(params["decoder.blocks.0.ffn.output"]["bias"]) == {:bf, 16}
+
+      assert {:ok, %{params: params}} =
+               Bumblebee.load_model({:hf, "hf-internal-testing/tiny-random-GPT2Model"},
+                 type: Axon.MixedPrecision.create_policy(params: :f16)
+               )
+
+      assert Nx.type(params["decoder.blocks.0.ffn.output"]["kernel"]) == {:f, 16}
+      assert Nx.type(params["decoder.blocks.0.ffn.output"]["bias"]) == {:f, 16}
+    end
   end
 end


### PR DESCRIPTION
Allows for `Bumblebee.load_model({:hf, "..."}, type: :bf16)` to set mixed precision policy on the model and cast params on load. The user can also pass the policy struct itself, type is just a shorthand.

Note: currently loading a f16 checkpoint returns params in f16, but that's somewhat a bug, specifically if all params are available we skip Axon init, which would otherwise cast the params to f32. Now it's going to always be f32 by default and the user can override it using `:type`.

hf/transformers look at `"torch_dtype"` in the config file to determine the type, but I'm not sure if we want to configure the policy automatically based on that. @seanmor5 thoughts?