### PR TITLE
Remove Bumblebee.Utils.Nx.to_list/1 in favour of Nx.to_list/1

### DIFF
--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -145,7 +145,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
   defp maybe_stream(serving, false, spec, featurizer, tokenizer, timestamps?) do
     Nx.Serving.client_postprocessing(serving, fn
       {outputs, _metadata}, {multi?, all_num_chunks, lengths} ->
-        chunk_outputs = Bumblebee.Utils.Nx.to_list(outputs)
+        chunk_outputs = Nx.to_list(outputs)
 
         all_num_chunks
         |> Enum.map_reduce(chunk_outputs, fn num_chunks, chunk_outputs ->
@@ -166,7 +166,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
       state = decode_chunk_outputs_init(lengths, spec, featurizer, tokenizer)
 
       Stream.transform(stream, state, fn {:batch, outputs, _metadata}, state ->
-        outputs = Bumblebee.Utils.Nx.to_list(outputs)
+        outputs = Nx.to_list(outputs)
         decode_chunk_outputs_update(state, outputs, timestamps?, tokenizer)
       end)
     end)

--- a/lib/bumblebee/text/fill_mask.ex
+++ b/lib/bumblebee/text/fill_mask.ex
@@ -102,8 +102,8 @@ defmodule Bumblebee.Text.FillMask do
     end)
     |> Nx.Serving.client_postprocessing(fn {{top_scores, top_indices}, _metadata}, multi? ->
       Enum.zip_with(
-        Bumblebee.Utils.Nx.to_list(top_scores),
-        Bumblebee.Utils.Nx.to_list(top_indices),
+        Nx.to_list(top_scores),
+        Nx.to_list(top_indices),
         fn top_scores, top_indices ->
           predictions =
             Enum.zip_with(top_scores, top_indices, fn score, token_id ->

--- a/lib/bumblebee/text/text_classification.ex
+++ b/lib/bumblebee/text/text_classification.ex
@@ -86,8 +86,8 @@ defmodule Bumblebee.Text.TextClassification do
     end)
     |> Nx.Serving.client_postprocessing(fn {{top_scores, top_indices}, _metadata}, multi? ->
       Enum.zip_with(
-        Bumblebee.Utils.Nx.to_list(top_scores),
-        Bumblebee.Utils.Nx.to_list(top_indices),
+        Nx.to_list(top_scores),
+        Nx.to_list(top_indices),
         fn top_scores, top_indices ->
           predictions =
             Enum.zip_with(top_scores, top_indices, fn score, idx ->

--- a/lib/bumblebee/text/zero_shot_classification.ex
+++ b/lib/bumblebee/text/zero_shot_classification.ex
@@ -111,8 +111,8 @@ defmodule Bumblebee.Text.ZeroShotClassification do
     end)
     |> Nx.Serving.client_postprocessing(fn {{top_scores, top_indices}, _metadata}, multi? ->
       Enum.zip_with(
-        Bumblebee.Utils.Nx.to_list(top_scores),
-        Bumblebee.Utils.Nx.to_list(top_indices),
+        Nx.to_list(top_scores),
+        Nx.to_list(top_indices),
         fn top_scores, top_indices ->
           predictions =
             Enum.zip_with(top_scores, top_indices, fn score, idx ->

--- a/lib/bumblebee/tokenizer.ex
+++ b/lib/bumblebee/tokenizer.ex
@@ -78,7 +78,7 @@ defmodule Bumblebee.Tokenizer do
           token() | list(token_id()) | list(list(token_id())) | Nx.Tensor.t()
         ) :: String.t()
   def decode(%module{} = tokenizer, ids) do
-    ids = with %Nx.Tensor{} <- ids, do: Bumblebee.Utils.Nx.to_list(ids)
+    ids = with %Nx.Tensor{} <- ids, do: Nx.to_list(ids)
     ids = List.wrap(ids)
     module.decode(tokenizer, ids)
   end

--- a/lib/bumblebee/utils/nx.ex
+++ b/lib/bumblebee/utils/nx.ex
@@ -64,26 +64,6 @@ defmodule Bumblebee.Utils.Nx do
   end
 
   @doc """
-  Returns the underlying tensor as a list.
-
-  The list nesting matches the tensor shape.
-  """
-  # TODO: remove in v0.6
-  @deprecated "Use Nx.to_list/1 instead."
-  @spec to_list(Nx.Tensor.t()) :: list()
-  def to_list(tensor) do
-    list = Nx.to_flat_list(tensor)
-
-    tensor
-    |> Nx.shape()
-    |> Tuple.to_list()
-    |> Enum.drop(1)
-    |> Enum.reverse()
-    |> Enum.reduce(list, &Stream.chunk_every(&2, &1))
-    |> Enum.to_list()
-  end
-
-  @doc """
   Splits tensor or container along the first axis.
 
   Note: this function traverses the container N times, where N is the

--- a/lib/bumblebee/utils/nx.ex
+++ b/lib/bumblebee/utils/nx.ex
@@ -68,6 +68,8 @@ defmodule Bumblebee.Utils.Nx do
 
   The list nesting matches the tensor shape.
   """
+  # TODO: remove in v0.6
+  @deprecated "Use Nx.to_list/1 instead."
   @spec to_list(Nx.Tensor.t()) :: list()
   def to_list(tensor) do
     list = Nx.to_flat_list(tensor)

--- a/lib/bumblebee/vision/image_classification.ex
+++ b/lib/bumblebee/vision/image_classification.ex
@@ -70,8 +70,8 @@ defmodule Bumblebee.Vision.ImageClassification do
     end)
     |> Nx.Serving.client_postprocessing(fn {{top_scores, top_indices}, _metadata}, multi? ->
       Enum.zip_with(
-        Bumblebee.Utils.Nx.to_list(top_scores),
-        Bumblebee.Utils.Nx.to_list(top_indices),
+        Nx.to_list(top_scores),
+        Nx.to_list(top_indices),
         fn top_scores, top_indices ->
           predictions =
             Enum.zip_with(top_scores, top_indices, fn score, idx ->


### PR DESCRIPTION
After `Nx.to_list/1` (https://github.com/elixir-nx/nx/pull/1095) was added, the function `Bumblebee.Utils.Nx.to_list` became redundant.