### PR TITLE
Pass PRNG key to schedulers in Stable Diffusion

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -1048,10 +1048,11 @@ defmodule Bumblebee do
   @spec scheduler_init(
           Bumblebee.Scheduler.t(),
           non_neg_integer(),
-          tuple()
+          Nx.Tensor.t(),
+          Nx.Tensor.t()
         ) :: {Bumblebee.Scheduler.state(), Nx.Tensor.t()}
-  def scheduler_init(%module{} = scheduler, num_steps, sample_shape) do
-    module.init(scheduler, num_steps, sample_shape)
+  def scheduler_init(%module{} = scheduler, num_steps, sample_template, prng_key) do
+    module.init(scheduler, num_steps, sample_template, prng_key)
   end
 
   @doc """

--- a/lib/bumblebee/diffusion/ddim_scheduler.ex
+++ b/lib/bumblebee/diffusion/ddim_scheduler.ex
@@ -112,11 +112,7 @@ defmodule Bumblebee.Diffusion.DdimScheduler do
   end
 
   @impl true
-  def init(scheduler, num_steps, _sample_shape, opts \\ []) do
-    opts = Keyword.validate!(opts, [:seed])
-
-    seed = Keyword.get_lazy(opts, :seed, fn -> :erlang.system_time() end)
-
+  def init(scheduler, num_steps, _sample_template, prng_key) do
     timesteps =
       SchedulerUtils.ddim_timesteps(
         scheduler.num_train_steps,
@@ -124,7 +120,7 @@ defmodule Bumblebee.Diffusion.DdimScheduler do
         scheduler.timesteps_offset
       )
 
-    {alpha_bars, prng_key} = init_parameters(scheduler: scheduler, seed: seed)
+    {alpha_bars} = init_parameters(scheduler: scheduler)
 
     state = %{
       timesteps: timesteps,
@@ -145,9 +141,6 @@ defmodule Bumblebee.Diffusion.DdimScheduler do
       num_train_steps: num_train_steps
     } = opts[:scheduler]
 
-    seed = opts[:seed]
-    prng_key = Nx.Random.key(seed)
-
     betas =
       SchedulerUtils.beta_schedule(beta_schedule, num_train_steps,
         start: beta_start,
@@ -156,7 +149,7 @@ defmodule Bumblebee.Diffusion.DdimScheduler do
 
     alphas = 1 - betas
 
-    {Nx.cumulative_product(alphas), prng_key}
+    {Nx.cumulative_product(alphas)}
   end
 
   @impl true

--- a/lib/bumblebee/diffusion/lcm_scheduler.ex
+++ b/lib/bumblebee/diffusion/lcm_scheduler.ex
@@ -108,16 +108,15 @@ defmodule Bumblebee.Diffusion.LcmScheduler do
   end
 
   @impl true
-  def init(scheduler, num_steps, _sample_shape, opts \\ []) do
-    opts = Keyword.validate!(opts, [:seed, :strength])
+  def init(scheduler, num_steps, _sample_template, prng_key, opts \\ []) do
+    opts = Keyword.validate!(opts, [:strength])
 
-    seed = Keyword.get_lazy(opts, :seed, fn -> :erlang.system_time() end)
     strength = Keyword.get(opts, :strength, 1.0)
 
     timesteps =
       timesteps(num_steps, scheduler.num_original_steps, scheduler.num_train_steps, strength)
 
-    {alpha_bars, prng_key} = init_parameters(scheduler: scheduler, seed: seed)
+    {alpha_bars} = init_parameters(scheduler: scheduler)
 
     state = %{
       timesteps: timesteps,
@@ -179,9 +178,6 @@ defmodule Bumblebee.Diffusion.LcmScheduler do
       num_train_steps: num_train_steps
     } = opts[:scheduler]
 
-    seed = opts[:seed]
-    prng_key = Nx.Random.key(seed)
-
     betas =
       SchedulerUtils.beta_schedule(beta_schedule, num_train_steps,
         start: beta_start,
@@ -190,7 +186,7 @@ defmodule Bumblebee.Diffusion.LcmScheduler do
 
     alphas = 1 - betas
 
-    {Nx.cumulative_product(alphas), prng_key}
+    {Nx.cumulative_product(alphas)}
   end
 
   @impl true

--- a/lib/bumblebee/diffusion/pndm_scheduler.ex
+++ b/lib/bumblebee/diffusion/pndm_scheduler.ex
@@ -80,7 +80,7 @@ defmodule Bumblebee.Diffusion.PndmScheduler do
   end
 
   @impl true
-  def init(scheduler, num_steps, sample_shape) do
+  def init(scheduler, num_steps, sample_template, _prng_key) do
     timesteps =
       timesteps(
         scheduler.num_train_steps,
@@ -91,7 +91,11 @@ defmodule Bumblebee.Diffusion.PndmScheduler do
 
     alpha_bars = init_parameters(scheduler: scheduler)
 
-    empty = Nx.broadcast(0.0, sample_shape)
+    [empty, _] =
+      Nx.broadcast_vectors([
+        Nx.tensor(0.0, type: Nx.type(sample_template)) |> Nx.broadcast(sample_template),
+        sample_template
+      ])
 
     state = %{
       timesteps: timesteps,

--- a/lib/bumblebee/scheduler.ex
+++ b/lib/bumblebee/scheduler.ex
@@ -50,7 +50,8 @@ defmodule Bumblebee.Scheduler do
   @callback init(
               t(),
               num_steps :: pos_integer(),
-              sample_shape :: tuple()
+              sample_template :: Nx.Tensor.t(),
+              prng_key :: Nx.Tensor.t()
             ) :: {state :: map(), timesteps :: Nx.Tensor.t()}
 
   @doc """

--- a/test/bumblebee/diffusion/lcm_scheduler_test.exs
+++ b/test/bumblebee/diffusion/lcm_scheduler_test.exs
@@ -4,16 +4,19 @@ defmodule Bumblebee.Diffusion.LcmSchedulerTest do
   test "invalid inputs" do
     scheduler = Bumblebee.configure(Bumblebee.Diffusion.LcmScheduler)
 
+    sample_template = Nx.template({1, 32, 32, 4}, :f32)
+    key = Nx.Random.key(0)
+
     assert_raise ArgumentError,
                  "expected the number of steps to be less or equal to the number of training steps (1000), got: 1001",
                  fn ->
-                   Bumblebee.Diffusion.LcmScheduler.init(scheduler, 1001, {1, 32, 32, 4})
+                   Bumblebee.Diffusion.LcmScheduler.init(scheduler, 1001, sample_template, key)
                  end
 
     assert_raise ArgumentError,
                  "expected the number of steps to be less or equal to num_original_steps * strength (50 * 0.5). Either reduce the number of steps orincrease the strength",
                  fn ->
-                   Bumblebee.Diffusion.LcmScheduler.init(scheduler, 50, {1, 32, 32, 4},
+                   Bumblebee.Diffusion.LcmScheduler.init(scheduler, 50, sample_template, key,
                      strength: 0.5
                    )
                  end
@@ -21,14 +24,18 @@ defmodule Bumblebee.Diffusion.LcmSchedulerTest do
     assert_raise ArgumentError,
                  "expected the number of steps to be less or equal to the number of original steps (50), got: 51",
                  fn ->
-                   Bumblebee.Diffusion.LcmScheduler.init(scheduler, 51, {1, 32, 32, 4})
+                   Bumblebee.Diffusion.LcmScheduler.init(scheduler, 51, sample_template, key)
                  end
   end
 
   test "decreasing timesteps" do
     scheduler = Bumblebee.configure(Bumblebee.Diffusion.LcmScheduler)
 
-    {_state, timesteps} = Bumblebee.Diffusion.LcmScheduler.init(scheduler, 4, {1, 32, 32, 4})
+    sample_template = Nx.template({1, 32, 32, 4}, :f32)
+    key = Nx.Random.key(0)
+
+    {_state, timesteps} =
+      Bumblebee.Diffusion.LcmScheduler.init(scheduler, 4, sample_template, key)
 
     decreasing? =
       Nx.to_list(timesteps)


### PR DESCRIPTION
Propagates the per-input seed all the way to the scheduler.