### PR TITLE
Downcase label before checking equality

### DIFF
--- a/lib/bumblebee/text/zero_shot_classification.ex
+++ b/lib/bumblebee/text/zero_shot_classification.ex
@@ -38,7 +38,7 @@ defmodule Bumblebee.Text.ZeroShotClassification do
 
     entailment_id =
       Enum.find_value(spec.id_to_label, fn {id, label} ->
-        label == "entailment" && id
+        String.downcase(label) == "entailment" && id
       end)
 
     unless entailment_id do


### PR DESCRIPTION
Sometimes labels are in uppercase. So the library raises `(ArgumentError) expected model specification to include "entailment" label in :id_to_label` when building the zero shot classification.

For example here: https://huggingface.co/typeform/distilbert-base-uncased-mnli/blob/main/config.json

I tested this commit and it allows me to use the above mentioned model.

The code I used to test this commit:
```elixir
Nx.default_backend({EXLA.Backend, []})

hf_model = "typeform/distilbert-base-uncased-mnli"

{:ok, model} = Bumblebee.load_model({:hf, hf_model})
{:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "distilbert/distilbert-base-uncased"})

serving = Bumblebee.Text.zero_shot_classification(model, tokenizer, ["Is clothes", "Is food"])

Nx.Serving.run(serving, "Steak is tasty")
  ```

Thank you for reviewing.