### PR TITLE
Change image size to maps in image featurizers

### DIFF
--- a/lib/bumblebee/shared/converters.ex
+++ b/lib/bumblebee/shared/converters.ex
@@ -218,4 +218,34 @@ defmodule Bumblebee.Shared.Converters do
       end
     end
   end
+
+  def image_size(opts \\ []) do
+    opts = Keyword.validate!(opts, single_as: :both_edges)
+    single_as = opts[:single_as]
+
+    true = single_as in [:both_edges, :shortest_edge]
+
+    fn name, value ->
+      case value do
+        %{"height" => height, "width" => width} ->
+          {:ok, %{height: height, width: width}}
+
+        [height, width] ->
+          {:ok, %{height: height, width: width}}
+
+        size when is_number(size) and single_as == :both_edges ->
+          {:ok, %{height: size, width: size}}
+
+        size when is_number(size) and single_as == :shortest_edge ->
+          {:ok, %{shortest_edge: size}}
+
+        %{"shortest_edge" => shortest_edge} ->
+          {:ok, %{shortest_edge: shortest_edge}}
+
+        _ ->
+          {:error,
+           "expected #{inspect(name)} to be a number, a list or a map with height and width, got: #{inspect(value)}"}
+      end
+    end
+  end
 end

--- a/lib/bumblebee/vision/convnext_featurizer.ex
+++ b/lib/bumblebee/vision/convnext_featurizer.ex
@@ -121,7 +121,7 @@ defmodule Bumblebee.Vision.ConvNextFeaturizer do
       opts =
         convert!(data,
           resize: {"do_resize", boolean()},
-          size: {"size", number()},
+          size: {"size", size()},
           resize_method: {"resample", resize_method()},
           crop_percentage: {"crop_pct", number()},
           normalize: {"do_normalize", boolean()},
@@ -130,6 +130,26 @@ defmodule Bumblebee.Vision.ConvNextFeaturizer do
         )
 
       @for.config(featurizer, opts)
+    end
+
+    defp size() do
+      # Note that in contrast to other featurizers, in this case size
+      # is always a single number and its meaning depends on the input
+      # size. huggingface/transformers put it under the "shortest_edge"
+      # key, but we keep it as a single number as it is more clear.
+      fn name, value ->
+        case value do
+          %{"shortest_edge" => size} ->
+            {:ok, size}
+
+          size when is_number(size) ->
+            {:ok, size}
+
+          _ ->
+            {:error,
+             "expected #{inspect(name)} to be a number or a map with shortest_edge, got: #{inspect(value)}"}
+        end
+      end
     end
   end
 end

--- a/lib/bumblebee/vision/vit_featurizer.ex
+++ b/lib/bumblebee/vision/vit_featurizer.ex
@@ -7,10 +7,10 @@ defmodule Bumblebee.Vision.VitFeaturizer do
       doc: "whether to resize the input to the given `:size`"
     ],
     size: [
-      default: 224,
+      default: %{height: 224, width: 224},
       doc: """
-      the size to resize the input to. Either a single number or a `{height, width}` tuple.
-      Only has an effect if `:resize` is `true`
+      the size to resize the input to, given as `%{height: ..., width: ...}`. Only has
+      an effect if `:resize` is `true`
       """
     ],
     resize_method: [
@@ -65,8 +65,8 @@ defmodule Bumblebee.Vision.VitFeaturizer do
         |> Image.normalize_channels(length(featurizer.image_mean))
 
       if featurizer.resize do
-        size = Image.normalize_size(featurizer.size)
-        NxImage.resize(images, size, method: featurizer.resize_method)
+        %{height: height, width: width} = featurizer.size
+        NxImage.resize(images, {height, width}, method: featurizer.resize_method)
       else
         images
       end
@@ -76,7 +76,7 @@ defmodule Bumblebee.Vision.VitFeaturizer do
 
   @impl true
   def batch_template(featurizer, batch_size) do
-    {height, width} = Image.normalize_size(featurizer.size)
+    %{height: height, width: width} = featurizer.size
     num_channels = length(featurizer.image_mean)
     Nx.template({batch_size, height, width, num_channels}, :f32)
   end
@@ -106,7 +106,7 @@ defmodule Bumblebee.Vision.VitFeaturizer do
       opts =
         convert!(data,
           resize: {"do_resize", boolean()},
-          size: {"size", one_of([number(), tuple([number(), number()])])},
+          size: {"size", image_size()},
           resize_method: {"resample", resize_method()},
           normalize: {"do_normalize", boolean()},
           image_mean: {"image_mean", list(number())},


### PR DESCRIPTION
Initially CLIP was using a single integer as size and always resized the shortest edge. Now it supports both fixed height-width and shortest edge resizing (there is padding on top of it, so the shape is still static).

I updated all featurizers to use maps, such as `%{height: 224, width: 224}` and `%{shortest_edge: 224}`. This matches hf/transformers and in the feature we may need to support more of these (for other featurizers).