### PR TITLE
Group cache files by repository

### DIFF
--- a/lib/bumblebee/huggingface/hub.ex
+++ b/lib/bumblebee/huggingface/hub.ex
@@ -47,6 +47,9 @@ defmodule Bumblebee.HuggingFace.Hub do
       ETag value, however if the value is already known, it can be
       passed as an option instead (to skip the extra request)
 
+    * `:cache_scope` - a namespace to put the cached files under in
+      the cache directory
+
   """
   @spec cached_download(String.t(), keyword()) :: {:ok, String.t()} | {:error, String.t()}
   def cached_download(url, opts \\ []) do
@@ -55,6 +58,13 @@ defmodule Bumblebee.HuggingFace.Hub do
     auth_token = opts[:auth_token]
 
     dir = Path.join(cache_dir, "huggingface")
+
+    dir =
+      if cache_scope = opts[:cache_scope] do
+        Path.join(dir, cache_scope)
+      else
+        dir
+      end
 
     File.mkdir_p!(dir)
 


### PR DESCRIPTION
Currently our cache directory has flat structure, where for each cached file we have one `.json` file with metadata and another with file contents. The file names are URL hashes or etags, so they are not meaningful to the user.

The cache should be opaque to the user, however it's easy to accumulate a lot of models, but clearing the whole cache is not ideal, since the user may want to remove only the models they no longer plan to use. For this purpose, this PR groups all cache files related to a specific HF repository in a separate subdirectory with meaningful name.

As a result, the existing caches will be invalidated, but I think it's worth it and we can just mention in the changelog that users should clear the cache.