### PR TITLE
Add token summary to text generation output

### DIFF
--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -52,7 +52,8 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     generate_fun = fn params, {inputs, seed} ->
       inputs = Bumblebee.Featurizer.process_batch(featurizer, inputs)
       inputs = Map.put(inputs, "seed", seed)
-      generate_fun.(params, inputs)
+      %{token_ids: token_ids} = generate_fun.(params, inputs)
+      token_ids
     end
 
     Nx.Serving.new(

--- a/lib/bumblebee/text.ex
+++ b/lib/bumblebee/text.ex
@@ -129,7 +129,12 @@ defmodule Bumblebee.Text do
   @type generation_input ::
           String.t() | %{:text => String.t(), optional(:seed) => integer()}
   @type generation_output :: %{results: list(generation_result())}
-  @type generation_result :: %{text: String.t()}
+  @type generation_result :: %{text: String.t(), token_summary: token_summary()}
+  @type token_summary :: %{
+          input: pos_integer(),
+          outout: pos_integer(),
+          padding: non_neg_integer()
+        }
 
   @doc """
   Builds serving for prompt-driven text generation.
@@ -171,6 +176,12 @@ defmodule Bumblebee.Text do
       when using streaming, only a single input can be given to the
       serving. To process a batch, call the serving with each input
       separately. Defaults to `false`
+
+    * `:stream_done` - when `:stream` is enabled, this enables a final
+      event, after all chunks have been emitted. The event has the
+      shape `{:done, result}`, where `result` includes the same fields
+      as `t:generation_result/0`, except for `:text`, which has been
+      already streamed. Defaults to `false`
 
   ## Examples
 

--- a/lib/bumblebee/vision/image_to_text.ex
+++ b/lib/bumblebee/vision/image_to_text.ex
@@ -34,7 +34,8 @@ defmodule Bumblebee.Vision.ImageToText do
     generate_fun = fn params, {inputs, seed} ->
       inputs = Bumblebee.Featurizer.process_batch(featurizer, inputs)
       inputs = Map.put(inputs, "seed", seed)
-      generate_fun.(params, inputs)
+      %{token_ids: token_ids} = generate_fun.(params, inputs)
+      token_ids
     end
 
     Nx.Serving.new(

--- a/test/bumblebee/text/bart_test.exs
+++ b/test/bumblebee/text/bart_test.exs
@@ -150,7 +150,7 @@ defmodule Bumblebee.Text.BartTest do
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)
 
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
-    token_ids = generate.(params, inputs)
+    %{token_ids: token_ids} = generate.(params, inputs)
 
     assert_equal(token_ids, Nx.tensor([[988, 988, 988]]))
   end

--- a/test/bumblebee/text/blenderbot_test.exs
+++ b/test/bumblebee/text/blenderbot_test.exs
@@ -79,7 +79,7 @@ defmodule Bumblebee.Text.BlenderbotTest do
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)
 
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
-    token_ids = generate.(params, inputs)
+    %{token_ids: token_ids} = generate.(params, inputs)
 
     assert_equal(token_ids, Nx.tensor([[382, 382, 382]]))
   end

--- a/test/bumblebee/text/mbart_test.exs
+++ b/test/bumblebee/text/mbart_test.exs
@@ -148,7 +148,7 @@ defmodule Bumblebee.Text.MbartTest do
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)
 
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
-    token_ids = generate.(params, inputs)
+    %{token_ids: token_ids} = generate.(params, inputs)
 
     assert_equal(token_ids, Nx.tensor([[230_521, 20386, 20386]]))
   end

--- a/test/bumblebee/text/t5_test.exs
+++ b/test/bumblebee/text/t5_test.exs
@@ -161,7 +161,7 @@ defmodule Bumblebee.Text.T5Test do
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)
 
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
-    token_ids = generate.(params, inputs)
+    %{token_ids: token_ids} = generate.(params, inputs)
 
     assert_equal(token_ids, Nx.tensor([[0, 0, 0]]))
   end
@@ -190,7 +190,7 @@ defmodule Bumblebee.Text.T5Test do
     generation_config = Bumblebee.configure(generation_config, max_new_tokens: 3)
 
     generate = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
-    token_ids = generate.(params, inputs)
+    %{token_ids: token_ids} = generate.(params, inputs)
 
     assert_equal(token_ids, Nx.tensor([[6161, 29516, 9788]]))
   end

--- a/test/bumblebee/text/text_generation_test.exs
+++ b/test/bumblebee/text/text_generation_test.exs
@@ -100,7 +100,7 @@ defmodule Bumblebee.Text.TextGenerationTest do
     serving = Bumblebee.Text.generation(model_info, tokenizer, generation_config, stream: true)
 
     stream = Nx.Serving.run(serving, article)
-    assert Enum.to_list(stream) == ["PG&E", " plans", " blackouts", " to", " reduce"]
+    assert Enum.to_list(stream) == ["PG&E", " plans", " blackouts", " to reduce"]
 
     # Raises when a batch is given
     assert_raise ArgumentError,
@@ -108,5 +108,62 @@ defmodule Bumblebee.Text.TextGenerationTest do
                  fn ->
                    Nx.Serving.run(serving, [article])
                  end
+  end
+
+  test "token summary" do
+    {:ok, model_info} = Bumblebee.load_model({:hf, "gpt2"})
+    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "gpt2"})
+    {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "gpt2"})
+
+    generation_config = Bumblebee.configure(generation_config, max_new_tokens: 8)
+
+    serving = Bumblebee.Text.generation(model_info, tokenizer, generation_config)
+
+    assert %{
+             results: [
+               %{
+                 text: ", I am a man of light.",
+                 token_summary: %{input: 2, output: 8, padding: 0}
+               }
+             ]
+           } = Nx.Serving.run(serving, "Hello darkness")
+
+    serving =
+      Bumblebee.Text.generation(model_info, tokenizer, generation_config,
+        compile: [batch_size: 1, sequence_length: 10]
+      )
+
+    # With padding
+
+    assert %{
+             results: [
+               %{
+                 text: ", I am a man of light.",
+                 token_summary: %{input: 2, output: 8, padding: 8}
+               }
+             ]
+           } = Nx.Serving.run(serving, "Hello darkness")
+
+    # With streaming
+
+    serving =
+      Bumblebee.Text.generation(model_info, tokenizer, generation_config,
+        compile: [batch_size: 1, sequence_length: 10],
+        stream: true,
+        stream_done: true
+      )
+
+    stream = Nx.Serving.run(serving, "Hello darkness")
+
+    assert Enum.to_list(stream) == [
+             ",",
+             " I",
+             " am",
+             " a",
+             " man",
+             " of",
+             " light.",
+             {:done, %{token_summary: %{input: 2, output: 8, padding: 8}}}
+           ]
   end
 end


### PR DESCRIPTION
Closes #287.

The summary looks like this `token_summary: %{input: 5, output: 20, padding: 95}`. When streaming, there is a new option `:stream_done`, which enables a final message and includes the usual result except for text, for example `{:done, %{token_summary: ...}}`.