### PR TITLE
Reduce the output of generation loop when streaming

### DIFF
--- a/lib/bumblebee/text/text_generation.ex
+++ b/lib/bumblebee/text/text_generation.ex
@@ -42,7 +42,10 @@ defmodule Bumblebee.Text.TextGeneration do
         return_length: true
       )
 
-    generate_fun = Bumblebee.Text.Generation.build_generate(model, spec, generation_config)
+    generate_fun =
+      Bumblebee.Text.Generation.build_generate(model, spec, generation_config,
+        ignore_output: opts[:stream]
+      )
 
     batch_keys = Shared.sequence_batch_keys(sequence_length)
 


### PR DESCRIPTION
When streaming tokens, we don't care about the generation final output. This PR changes the result to a zeroed tensor with shape `{batch_size}` (so it can be split by the serving).