### PR TITLE
Add :spec_overrides to Bumblebee.load_model/2

### DIFF
--- a/test/bumblebee/vision/dino_v2_test.exs
+++ b/test/bumblebee/vision/dino_v2_test.exs
@@ -143,14 +143,9 @@ defmodule Bumblebee.Vision.DinoV2Test do
   end
 
   test ":backbone with different feature map subset" do
-    assert {:ok, spec} =
-             Bumblebee.load_spec({:hf, "hf-internal-testing/tiny-random-Dinov2Backbone"})
-
-    spec = Bumblebee.configure(spec, backbone_output_indices: [0, 2])
-
     assert {:ok, %{model: model, params: params, spec: spec}} =
              Bumblebee.load_model({:hf, "hf-internal-testing/tiny-random-Dinov2Backbone"},
-               spec: spec
+               spec_overrides: [backbone_output_indices: [0, 2]]
              )
 
     assert %Bumblebee.Vision.DinoV2{architecture: :backbone} = spec


### PR DESCRIPTION
```elixir
{:ok, spec} = Bumblebee.load_spec({:hf, "microsoft/resnet-50"})
spec = Bumblebee.configure(spec, num_labels: 10)
{:ok, resnet} = Bumblebee.load_model({:hf, "microsoft/resnet-50"}, spec: spec)
```

->

```elixir
{:ok, resnet} =
  Bumblebee.load_model({:hf, "microsoft/resnet-50"}, spec_overrides: [num_labels: 10])
```

I considered accepting a keyword list for `:spec`, but probably better to kept them separate for clarity.