### PR TITLE
Update LLM docs

### DIFF
--- a/examples/phoenix/README.md
+++ b/examples/phoenix/README.md
@@ -79,8 +79,6 @@ serving =
   )
 ```
 
-Also see the [Llama example](../../notebooks/llama.livemd) for more option combinations.
-
 ### User images
 
 When working with user-given images, the most trivial approach would be to just upload an image as is, in a format like PNG or JPEG. However, this approach has two downsides:

--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Bumblebee.MixProject do
       extras: [
         "notebooks/examples.livemd",
         "notebooks/stable_diffusion.livemd",
-        "notebooks/llama.livemd",
+        "notebooks/llms.livemd",
         "notebooks/fine_tuning.livemd"
       ],
       extra_section: "GUIDES",

--- a/notebooks/llama.livemd
+++ b/notebooks/llama.livemd
@@ -17,7 +17,7 @@ In this notebook we look at running [Meta's Llama](https://ai.meta.com/llama/) m
 
 <!-- livebook:{"break_markdown":true} -->
 
-> **Note:** this is a very involved model, so the generation can take a long time if you run it on a CPU. Also, running on the GPU currently requires at least 16GB of VRAM, though at least 30GB is recommended for optimal runtime.
+> **Note:** this is a very involved model, so the generation can take a long time if you run it on a CPU. Also, running on the GPU currently requires at least 16.3GiB of VRAM (or 15.5GiB with lower speed, see below).
 
 ## Text generation
 
@@ -29,10 +29,7 @@ Let's load the model and create a serving for text generation:
 hf_token = System.fetch_env!("LB_HF_TOKEN")
 repo = {:hf, "meta-llama/Llama-2-7b-chat-hf", auth_token: hf_token}
 
-# Option 1
-# {:ok, model_info} = Bumblebee.load_model(repo, type: :bf16, backend: EXLA.Backend)
-# Option 2 and 3
-{:ok, model_info} = Bumblebee.load_model(repo, type: :bf16)
+{:ok, model_info} = Bumblebee.load_model(repo, type: :bf16, backend: EXLA.Backend)
 {:ok, tokenizer} = Bumblebee.load_tokenizer(repo)
 {:ok, generation_config} = Bumblebee.load_generation_config(repo)
 
@@ -50,25 +47,16 @@ serving =
   Bumblebee.Text.generation(model_info, tokenizer, generation_config,
     compile: [batch_size: 1, sequence_length: 1028],
     stream: true,
-    # Option 1 and 2
-    # defn_options: [compiler: EXLA]
-    # Option 3
-    defn_options: [compiler: EXLA, lazy_transfers: :always]
+    defn_options: [compiler: EXLA]
   )
 
 # Should be supervised
 Kino.start_child({Nx.Serving, name: Llama, serving: serving})
 ```
 
-We adjust the generation config to use a non-deterministic generation strategy. The most interesting part, though, is the combination of serving options.
+We adjust the generation config to use a non-deterministic generation strategy.
 
-First, note that in the Setup cell we set the default backend to `{EXLA.Backend, client: :host}`, which means that by default we load the parameters onto CPU. There are a couple combinations of options related to parameters, trading off memory usage for speed:
-
-1. `Bumblebee.load_model(..., backend: EXLA.Backend)`, `defn_options: [compiler: EXLA]` - load all parameters directly onto the GPU. This requires the most memory, but it should provide the fastest inference time. In case you are using multiple GPUs (and a partitioned serving), you still want to load the parameters onto the CPU first and instead use `preallocate_params: true`, so that the parameters are copied onto each of them.
-
-2. `defn_options: [compiler: EXLA]` - copy all parameters to the GPU before each computation and discard afterwards (or more specifically, when no longer needed in the computation). This requires less memory, but the copying increases the inference time.
-
-3. `defn_options: [compiler: EXLA, lazy_transfers: :always]` - lazily copy parameters to the GPU during the computation as needed. This requires the least memory, at the cost of inference time.
+Note that we load the parameters directly onto the GPU with `Bumblebee.load_model(..., backend: EXLA.Backend)` and with `defn_options: [compiler: EXLA]` we tell the serving to compile and run computations on the GPU as well.
 
 As for the other options, we specify `:compile` with fixed shapes, so that the model is compiled only once and inputs are always padded to match these shapes. We also enable `:stream` to receive text chunks as the generation is progressing.
 

--- a/notebooks/llms.livemd
+++ b/notebooks/llms.livemd
@@ -1,4 +1,4 @@
-# Llama
+# LLMs
 
 ```elixir
 Mix.install([
@@ -13,13 +13,19 @@ Nx.global_default_backend({EXLA.Backend, client: :host})
 
 ## Introduction
 
-In this notebook we look at running [Meta's Llama](https://ai.meta.com/llama/) model, specifically Llama 2, one of the most powerful open source Large Language Models (LLMs).
+In this notebook we outline the general setup for running a Large Langauge Model (LLM).
+
+<!-- livebook:{"branch_parent_index":0} -->
+
+## Llama 2
+
+In this section we look at running [Meta's Llama](https://ai.meta.com/llama/) model, specifically Llama 2, one of the most powerful open source Large Language Models (LLMs).
 
 <!-- livebook:{"break_markdown":true} -->
 
-> **Note:** this is a very involved model, so the generation can take a long time if you run it on a CPU. Also, running on the GPU currently requires at least 16.3GiB of VRAM (or 15.5GiB with lower speed, see below).
+> **Note:** this is a very involved model, so the generation can take a long time if you run it on a CPU. Also, running on the GPU currently requires at least 16.3GiB of VRAM.
 
-## Text generation
+<!-- livebook:{"break_markdown":true} -->
 
 In order to load Llama 2, you need to ask for access on [meta-llama/Llama-2-7b-chat-hf](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf). Once you are granted access, generate a [HuggingFace auth token](https://huggingface.co/settings/tokens) and put it in a `HF_TOKEN` Livebook secret.
 
@@ -54,9 +60,9 @@ serving =
 Kino.start_child({Nx.Serving, name: Llama, serving: serving})
 ```
 
-We adjust the generation config to use a non-deterministic generation strategy.
-
 Note that we load the parameters directly onto the GPU with `Bumblebee.load_model(..., backend: EXLA.Backend)` and with `defn_options: [compiler: EXLA]` we tell the serving to compile and run computations on the GPU as well.
+
+We adjust the generation config to use a non-deterministic generation strategy, so that the model is able to produce a slightly different output every time.
 
 As for the other options, we specify `:compile` with fixed shapes, so that the model is compiled only once and inputs are always padded to match these shapes. We also enable `:stream` to receive text chunks as the generation is progressing.
 
@@ -76,4 +82,48 @@ If a question does not make any sense, or is not factually coherent, explain why
 """
 
 Nx.Serving.batched_run(Llama, prompt) |> Enum.each(&IO.write/1)
+```
+
+<!-- livebook:{"branch_parent_index":0} -->
+
+## Mistral
+
+We can easily test other LLMs, we just need to change the repository and possibly adjust the prompt template. In this example we run the [Mistral](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.2) model.
+
+```elixir
+repo = {:hf, "mistralai/Mistral-7B-Instruct-v0.2"}
+
+{:ok, model_info} = Bumblebee.load_model(repo, type: :bf16, backend: EXLA.Backend)
+{:ok, tokenizer} = Bumblebee.load_tokenizer(repo)
+{:ok, generation_config} = Bumblebee.load_generation_config(repo)
+
+:ok
+```
+
+```elixir
+generation_config =
+  Bumblebee.configure(generation_config,
+    max_new_tokens: 256,
+    strategy: %{type: :multinomial_sampling, top_p: 0.6}
+  )
+
+serving =
+  Bumblebee.Text.generation(model_info, tokenizer, generation_config,
+    compile: [batch_size: 1, sequence_length: 1028],
+    stream: true,
+    defn_options: [compiler: EXLA]
+  )
+
+# Should be supervised
+Kino.start_child({Nx.Serving, name: Mistral, serving: serving})
+```
+
+```elixir
+prompt = """
+<s>[INST] What is your favourite condiment? [/INST]
+Well, I'm quite partial to a good squeeze of fresh lemon juice. It adds just the right amount of zesty flavour to whatever I'm cooking up in the kitchen!</s>
+[INST] Do you have mayonnaise recipes? [/INST]\
+"""
+
+Nx.Serving.batched_run(Mistral, prompt) |> Enum.each(&IO.write/1)
 ```

--- a/notebooks/stable_diffusion.livemd
+++ b/notebooks/stable_diffusion.livemd
@@ -17,7 +17,7 @@ Stable Diffusion is a latent text-to-image diffusion model, primarily used to ge
 
 <!-- livebook:{"break_markdown":true} -->
 
-> **Note:** Stable Diffusion is a very involved model, so the generation can take a long time if you run it on a CPU. Also, running on the GPU currently requires at least 5GB of VRAM (or 3GB with lower speed, see below).
+> **Note:** Stable Diffusion is a very involved model, so the generation can take a long time if you run it on a CPU. Also, running on the GPU currently requires at least 5GiB of VRAM (or 3GiB with lower speed, see below).
 
 <!-- livebook:{"branch_parent_index":0} -->
 
@@ -27,7 +27,7 @@ Stable Diffusion is composed of several separate models and preprocessors, so we
 
 ```elixir
 repo_id = "CompVis/stable-diffusion-v1-4"
-opts = [params_variant: "fp16", type: :bf16]
+opts = [params_variant: "fp16", type: :bf16, backend: EXLA.Backend]
 
 {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/clip-vit-large-patch14"})
 {:ok, clip} = Bumblebee.load_model({:hf, repo_id, subdir: "text_encoder"}, opts)
@@ -55,9 +55,9 @@ serving =
     safety_checker_featurizer: featurizer,
     compile: [batch_size: 1, sequence_length: 60],
     # Option 1
-    preallocate_params: true,
     defn_options: [compiler: EXLA]
     # Option 2 (reduces GPU usage, but runs noticeably slower)
+    # Also remove `backend: EXLA.Backend` from the loading options above
     # defn_options: [compiler: EXLA, lazy_transfers: :always]
   )
 


### PR DESCRIPTION
I did another iteration of this. Currently running LLaMa 7B with params on the GPU requires 16.3GiB of memory. Params on the CPU + lazy transfers require 15.5GiB, which is almost negligible and given that it adds latency of like x4 inference time, I think it's no longer worth mentioning. Sidenote: lazy transfers don't really change anything here and that's what I would expect, since generation loops over the model and therefor all params need to be on the GPU. I'm sure how not having params on the GPU makes a difference, since they can't be garbage collected early either, but the difference is very tiny anyway.

Note that for Stable Diffusion params on the CPU + lazy transfers has more impact, because it uses several models, so once one finishes its params can be garbage collected and the next model params can be loaded lazily, so it does make sense.

I also added an example with Mistral.