### PR TITLE
Support stream input in Whisper serving and stream ffmpeg chunks

### DIFF
--- a/lib/bumblebee/audio.ex
+++ b/lib/bumblebee/audio.ex
@@ -10,11 +10,14 @@ defmodule Bumblebee.Audio do
 
     * a 1-dimensional `Nx.Tensor` with audio samples
 
+    * an enumerable of 1-dimensional `Nx.Tensor`s, represending a
+      continuous stream of input
+
     * `{:file, path}` with path to an audio file (note that this
       requires `ffmpeg` installed)
 
   """
-  @type audio :: Nx.t() | {:file, String.t()}
+  @type audio :: Nx.t() | Enumerable.t(Nx.t()) | {:file, String.t()}
 
   @type speech_to_text_whisper_input ::
           audio() | %{:audio => audio(), optional(:seed) => integer() | nil}
@@ -31,7 +34,11 @@ defmodule Bumblebee.Audio do
   Builds serving for speech-to-text generation with Whisper models.
 
   The serving accepts `t:speech_to_text_whisper_input/0` and returns
-  `t:speech_to_text_whisper_output/0`. A list of inputs is also supported.
+  `t:speech_to_text_whisper_output/0`.
+
+  This serving always accepts a single input. A list of tensors is
+  interpreted as continuous chunks. To transcribe multiple inputs
+  concurrently use `Nx.Serving.batched_run/2`.
 
   ## Options
 

--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -30,7 +30,10 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     Shared.validate_architecture!(spec, [:for_conditional_generation])
 
     chunk_num_seconds = opts[:chunk_num_seconds]
-    context_num_seconds = opts[:context_num_seconds]
+
+    context_num_seconds =
+      opts[:context_num_seconds] || (chunk_num_seconds && chunk_num_seconds / 6)
+
     preallocate_params = opts[:preallocate_params]
     defn_options = opts[:defn_options]
 
@@ -45,6 +48,13 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
 
     sampling_rate = featurizer.sampling_rate
     timestamps? = opts[:timestamps] != nil
+
+    options = %{
+      timestamps?: timestamps?,
+      sampling_rate: sampling_rate,
+      chunk_num_seconds: chunk_num_seconds,
+      context_num_seconds: context_num_seconds
+    }
 
     {generate_opts, generation_config} = generate_opts(generation_config, opts)
     generate_fun = Text.Generation.build_generate(model, spec, generation_config, generate_opts)
@@ -76,101 +86,144 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     )
     |> Nx.Serving.batch_size(batch_size)
     |> Nx.Serving.client_preprocessing(fn input ->
-      if opts[:stream] do
-        Shared.validate_input_for_stream!(input)
-      end
-
-      {inputs, multi?} = Shared.validate_serving_input!(input, &validate_input(&1, sampling_rate))
-
-      all_chunks =
-        for input <- inputs do
-          if chunk_num_seconds do
-            chunks =
-              chunk_input(input.audio, sampling_rate, chunk_num_seconds, context_num_seconds)
-
-            for {chunk, lengths} <- chunks, do: {{chunk, input.seed}, lengths}
-          else
-            [{{input.audio, input.seed}, nil}]
-          end
+      %{audio: audio, seed: seed} =
+        case validate_input(input, sampling_rate, chunk_num_seconds) do
+          {:ok, input} -> input
+          {:error, message} -> raise ArgumentError, "invalid input, #{message}"
         end
 
-      all_num_chunks = Enum.map(all_chunks, &length/1)
+      chunks =
+        if chunk_num_seconds do
+          chunk_input(audio, sampling_rate, chunk_num_seconds, context_num_seconds)
+        else
+          audio
+        end
 
-      all_chunks = List.flatten(all_chunks)
-      {all_chunks, lengths} = Enum.unzip(all_chunks)
+      stream =
+        chunks
+        # Unless batch_size is specified, we process chunks individually.
+        # When the whole audio chunk is given at once, this is all we
+        # need. When an enumerable is given, it can have an arbitarary
+        # number of elements, so processing them one by one makes for a
+        # reasonable default.
+        |> Stream.chunk_every(batch_size || 1)
+        |> Stream.map(fn chunks ->
+          seed =
+            seed
+            |> Nx.tensor(backend: Nx.BinaryBackend)
+            |> Nx.broadcast({length(chunks)})
 
-      if batch_size do
-        stream =
-          all_chunks
-          |> Stream.chunk_every(batch_size)
-          |> Stream.map(fn all_chunks ->
-            {all_chunks, seed} = Enum.unzip(all_chunks)
-            seed = Nx.tensor(seed, backend: Nx.BinaryBackend)
-            inputs = Bumblebee.Featurizer.process_input(featurizer, all_chunks)
-            Nx.Batch.concatenate([{inputs, seed}])
-          end)
+          inputs = Bumblebee.Featurizer.process_input(featurizer, chunks)
+          Nx.Batch.concatenate([{inputs, seed}])
+        end)
 
-        {stream, {multi?, all_num_chunks, lengths}}
-      else
-        {all_chunks, seed} = Enum.unzip(all_chunks)
-        seed = Nx.tensor(seed, backend: Nx.BinaryBackend)
-        inputs = Bumblebee.Featurizer.process_input(featurizer, all_chunks)
-        {Nx.Batch.concatenate([{inputs, seed}]), {multi?, all_num_chunks, lengths}}
-      end
+      {stream, {}}
     end)
-    |> maybe_stream(opts[:stream], spec, featurizer, tokenizer, timestamps?)
+    |> maybe_stream(opts[:stream], spec, featurizer, tokenizer, options)
   end
 
-  defp validate_input(%{audio: audio} = input, sampling_rate) do
-    with {:ok, audio} <- parse_audio(audio, sampling_rate) do
+  defp validate_input(%{audio: audio} = input, sampling_rate, chunk_num_seconds) do
+    with {:ok, audio} <- parse_audio(audio, sampling_rate, chunk_num_seconds) do
       {:ok, %{audio: audio, seed: input[:seed] || :erlang.system_time()}}
     end
   end
 
-  defp validate_input(input, sampling_rate), do: validate_input(%{audio: input}, sampling_rate)
+  defp validate_input(input, sampling_rate, chunk_num_seconds) do
+    validate_input(%{audio: input}, sampling_rate, chunk_num_seconds)
+  end
 
-  defp parse_audio(input, sampling_rate) do
+  defp parse_audio(input, sampling_rate, chunk_num_seconds) do
     case input do
       %Nx.Tensor{shape: {_}} = input ->
-        {:ok, Nx.backend_transfer(input, Nx.BinaryBackend)}
+        {:ok, [Nx.backend_transfer(input, Nx.BinaryBackend)]}
 
       {:file, path} when is_binary(path) ->
         ffmpeg_read_as_pcm(path, sampling_rate)
 
       other ->
-        {:error,
-         "expected audio to be a 1-dimensional tensor or {:file, path}, got: #{inspect(other)}"}
+        cond do
+          Enumerable.impl_for(other) == nil ->
+            {:error,
+             "expected audio to be a 1-dimensional tensor, an enumerable, or {:file, path}, got: #{inspect(other)}"}
+
+          chunk_num_seconds == nil ->
+            {:error,
+             "enumerable input is only supported when chunking is enabled, make sure to set :chunk_num_seconds"}
+
+          true ->
+            stream =
+              Stream.each(other, fn
+                %Nx.Tensor{shape: {_}} ->
+                  :ok
+
+                item ->
+                  raise ArgumentError,
+                        "expected each enumerable item to be a 1-dimensional tensor, got: #{inspect(item)}"
+              end)
+
+            {:ok, stream}
+        end
     end
   end
 
-  defp maybe_stream(serving, false, spec, featurizer, tokenizer, timestamps?) do
-    Nx.Serving.client_postprocessing(serving, fn
-      {outputs, _metadata}, {multi?, all_num_chunks, lengths} ->
-        chunk_outputs = Nx.to_list(outputs)
+  defp ffmpeg_read_as_pcm(path, sampling_rate) do
+    channels = 1
 
-        all_num_chunks
-        |> Enum.map_reduce(chunk_outputs, fn num_chunks, chunk_outputs ->
-          {outputs, rest} = Enum.split(chunk_outputs, num_chunks)
-          state = decode_chunk_outputs_init(lengths, spec, featurizer, tokenizer)
-          {chunks, _state} = decode_chunk_outputs_update(state, outputs, timestamps?, tokenizer)
-          {%{chunks: chunks}, rest}
-        end)
-        |> elem(0)
-        |> Shared.normalize_output(multi?)
-    end)
-  end
+    format =
+      case System.endianness() do
+        :little -> "f32le"
+        :big -> "f32be"
+      end
 
-  defp maybe_stream(serving, true, spec, featurizer, tokenizer, timestamps?) do
-    serving
-    |> Nx.Serving.streaming()
-    |> Nx.Serving.client_postprocessing(fn stream, {false = _multi?, _all_num_chunks, lengths} ->
-      state = decode_chunk_outputs_init(lengths, spec, featurizer, tokenizer)
+    cond do
+      System.find_executable("ffmpeg") == nil ->
+        {:error, "ffmpeg not found in PATH"}
 
-      Stream.transform(stream, state, fn {:batch, outputs, _metadata}, state ->
-        outputs = Nx.to_list(outputs)
-        decode_chunk_outputs_update(state, outputs, timestamps?, tokenizer)
-      end)
-    end)
+      not File.exists?(path) ->
+        {:error, "no file found at #{path}"}
+
+      true ->
+        # This chunk can be of arbitrary size, the serving accumulates
+        # and overlaps chunks internally as needed. We read the file
+        # as stream to reduce memory usage
+        chunk_size = 30
+
+        stream =
+          Stream.iterate(0, fn offset -> offset + chunk_size end)
+          |> Stream.transform({}, fn offset, acc ->
+            System.cmd("ffmpeg", [
+              "-ss",
+              Integer.to_string(offset),
+              "-t",
+              Integer.to_string(chunk_size),
+              "-i",
+              path,
+              "-ac",
+              Integer.to_string(channels),
+              "-ar",
+              Integer.to_string(sampling_rate),
+              "-f",
+              format,
+              "-hide_banner",
+              "-loglevel",
+              "quiet",
+              "pipe:1"
+            ])
+            |> case do
+              {<<>>, 0} ->
+                {:halt, acc}
+
+              {data, 0} ->
+                chunk = Nx.from_binary(data, :f32, backend: Nx.BinaryBackend)
+                {[chunk], acc}
+
+              {_, 1} ->
+                raise "ffmpeg failed to decode the given file"
+            end
+          end)
+
+        {:ok, stream}
+    end
   end
 
   defp generate_opts(generation_config, opts) do
@@ -253,132 +306,194 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     for {token_id, idx} <- Enum.with_index(token_ids, 1), token_id, do: {idx, token_id}
   end
 
-  defp chunk_input(input, sampling_rate, chunk_num_seconds, context_num_seconds) do
-    context_num_seconds = context_num_seconds || chunk_num_seconds / 6
-
+  # Takes a stream of continous tensor chunks and produces a stream of
+  # overlapping chunks
+  defp chunk_input(stream, sampling_rate, chunk_num_seconds, context_num_seconds) do
     chunk_length = floor(chunk_num_seconds * sampling_rate)
     context_left = floor(context_num_seconds * sampling_rate)
     context_right = context_left
 
-    input_length = Nx.axis_size(input, 0)
     step = chunk_length - context_left - context_right
 
-    0..(input_length - 1)//step
-    |> Enum.reduce_while([], fn chunk_start_idx, chunks ->
-      chunk_end_idx = chunk_start_idx + chunk_length
+    if step <= 0 do
+      raise ArgumentError,
+            ":chunk_num_seconds must be more than double the length of :context_num_seconds"
+    end
 
-      # All right contexts must be full, otherwise it is the last item
-      last? =
-        if context_right > 0 do
-          chunk_end_idx > input_length
-        else
-          chunk_end_idx >= input_length
-        end
+    Stream.transform(
+      stream,
+      fn ->
+        {[], 0}
+      end,
+      fn chunk, {buffer, buffer_size} ->
+        buffer_size = buffer_size + Nx.size(chunk)
+        buffer = buffer ++ [chunk]
+        full_chunks([], {buffer, buffer_size}, chunk_length, step)
+      end,
+      fn {buffer, buffer_size} ->
+        {[Nx.concatenate(buffer)], {buffer, buffer_size}}
+      end,
+      fn _ -> :ok end
+    )
+  end
 
-      context_left = if chunk_start_idx == 0, do: 0, else: context_left
-      context_right = if last?, do: 0, else: context_right
+  defp full_chunks(acc, {buffer, buffer_size}, chunk_length, _step)
+       when chunk_length > buffer_size do
+    {Enum.reverse(acc), {buffer, buffer_size}}
+  end
 
-      lengths =
-        {chunk_length / sampling_rate, context_left / sampling_rate,
-         context_right / sampling_rate}
+  defp full_chunks(acc, {buffer, buffer_size}, chunk_length, step) do
+    # We take `chunk_length` samples from the buffer, but drop only
+    # `step`, since the rest we need for the next chunk
+    {subchunks1, buffer} = slice_buffer(buffer, step, [])
+    {subchunks2, _buffer} = slice_buffer(buffer, chunk_length - step, [])
+    chunk = Nx.concatenate(subchunks1 ++ subchunks2)
+    buffer_size = buffer_size - step
+    full_chunks([chunk | acc], {buffer, buffer_size}, chunk_length, step)
+  end
 
-      chunk = input[chunk_start_idx..(min(chunk_end_idx, input_length) - 1)]
-      chunks = [{chunk, lengths} | chunks]
+  defp slice_buffer(buffer, 0, acc), do: {Enum.reverse(acc), buffer}
 
-      {if(last?, do: :halt, else: :cont), chunks}
+  defp slice_buffer([chunk | buffer], size, acc) do
+    chunk_size = Nx.size(chunk)
+
+    if chunk_size <= size do
+      slice_buffer(buffer, size - chunk_size, [chunk | acc])
+    else
+      {chunk, rest} = Nx.split(chunk, size)
+      slice_buffer([rest | buffer], 0, [chunk | acc])
+    end
+  end
+
+  defp maybe_stream(serving, false, spec, featurizer, tokenizer, options) do
+    Nx.Serving.client_postprocessing(serving, fn {outputs, _metadata}, {} ->
+      outputs = Nx.to_list(outputs)
+      state = decode_chunk_outputs_init(spec, featurizer, tokenizer)
+      {chunks, state} = decode_chunk_outputs_update(state, outputs, tokenizer, options)
+      {final_chunks, _state} = decode_chunk_outputs_finish(state, tokenizer, options)
+      chunks = chunks ++ final_chunks
+      Shared.normalize_output([%{chunks: chunks}], false)
     end)
-    |> Enum.reverse()
+  end
+
+  defp maybe_stream(serving, true, spec, featurizer, tokenizer, options) do
+    serving
+    |> Nx.Serving.streaming()
+    |> Nx.Serving.client_postprocessing(fn stream, {} ->
+      Stream.transform(
+        stream,
+        fn ->
+          decode_chunk_outputs_init(spec, featurizer, tokenizer)
+        end,
+        fn {:batch, outputs, _metadata}, state ->
+          outputs = Nx.to_list(outputs)
+          decode_chunk_outputs_update(state, outputs, tokenizer, options)
+        end,
+        fn state ->
+          decode_chunk_outputs_finish(state, tokenizer, options)
+        end,
+        fn _ -> :ok end
+      )
+    end)
   end
 
   # We generalize the decoding into multiple steps, where we feed a
   # number of outputs at a time. When not streaming we just feed all
   # outputs at once.
-  defp decode_chunk_outputs_init(lengths, spec, featurizer, tokenizer) do
+
+  defp decode_chunk_outputs_init(spec, featurizer, tokenizer) do
     time_precision = featurizer.num_seconds / spec.encoder_max_positions
     all_special_tokens = Bumblebee.Tokenizer.all_special_tokens(tokenizer)
     timestamp_begin_id = Bumblebee.Tokenizer.token_to_id(tokenizer, "<|notimestamps|>") + 1
 
-    acc = %{
+    %{
+      time_precision: time_precision,
+      all_special_tokens: all_special_tokens,
+      timestamp_begin_id: timestamp_begin_id,
+      # Accumulation state
       time_offset: 0,
+      right_context_end_time: nil,
       previous_sequences: [],
       current_sequence: [],
       chunks: [],
       chunk: empty_chunk()
     }
-
-    %{
-      acc: acc,
-      lengths: lengths,
-      time_precision: time_precision,
-      all_special_tokens: all_special_tokens,
-      timestamp_begin_id: timestamp_begin_id
-    }
   end
 
-  defp decode_chunk_outputs_update(state, outputs, timestamps?, tokenizer) do
+  defp decode_chunk_outputs_update(state, outputs, tokenizer, options) do
     %{
-      time_precision: time_precision,
+      timestamps?: timestamps?,
+      context_num_seconds: context_num_seconds
+    } = options
+
+    state =
+      Enum.reduce(outputs, state, fn sequence, state ->
+        process_output(state, sequence, tokenizer, options)
+      end)
+
+    state =
+      cond do
+        # If timestamps are enabled, chunks are finished on every end
+        # timestamp, otherwise we need to do it explicitly
+        timestamps? ->
+          state
+
+        # If context is enabled, we can emit chunks only once we have
+        # two consecutive sequences, because we need to merge their
+        # overlaps
+        context_num_seconds == nil or context_num_seconds == 0 or
+            at_least_2?(state.previous_sequences) ->
+          finish_chunk(state, tokenizer, options)
+
+        true ->
+          state
+      end
+
+    pop_chunks(state)
+  end
+
+  defp decode_chunk_outputs_finish(state, tokenizer, options) do
+    # Flush any pending sequences
+    state = finish_chunk(state, tokenizer, options)
+    pop_chunks(state)
+  end
+
+  defp at_least_2?([_, _ | _]), do: true
+  defp at_least_2?(_), do: false
+
+  defp pop_chunks(state) do
+    get_and_update_in(state.chunks, fn chunks ->
+      {Enum.reverse(chunks), []}
+    end)
+  end
+
+  defp process_output(state, sequence, tokenizer, options) do
+    %{
       timestamp_begin_id: timestamp_begin_id,
+      time_precision: time_precision,
       all_special_tokens: all_special_tokens
     } = state
 
-    batch_size = length(outputs)
+    %{
+      sampling_rate: sampling_rate,
+      chunk_num_seconds: chunk_num_seconds,
+      context_num_seconds: context_num_seconds
+    } = options
 
-    {lengths, lengths_rest} = Enum.split(state.lengths, batch_size)
-    state = %{state | lengths: lengths_rest}
+    chunk_length_seconds =
+      chunk_num_seconds && floor(chunk_num_seconds * sampling_rate) / sampling_rate
 
-    acc =
-      Enum.zip_reduce([outputs, lengths], state.acc, fn [sequence, lengths], acc ->
-        process_output(
-          sequence,
-          lengths,
-          timestamps?,
-          timestamp_begin_id,
-          time_precision,
-          tokenizer,
-          all_special_tokens,
-          acc
-        )
-      end)
+    context_left_seconds =
+      if(context_num_seconds,
+        do: floor(context_num_seconds * sampling_rate) / sampling_rate,
+        else: 0
+      )
 
-    acc =
-      if timestamps? do
-        acc
-      else
-        # We finish chunks on end timestamps, so with timestamps disabled
-        # we need to do this explicitly
+    context_right_seconds = context_left_seconds
 
-        acc = finish_chunk(acc, timestamps?, tokenizer)
+    context_left_seconds = if(state.time_offset == 0, do: 0, else: context_left_seconds)
 
-        finished? = state.lengths == []
-
-        if finished? do
-          # Flush any pending sequences
-          finish_chunk(acc, timestamps?, tokenizer)
-        else
-          acc
-        end
-      end
-
-    chunks = Enum.reverse(acc.chunks)
-    acc = %{acc | chunks: []}
-    {chunks, %{state | acc: acc}}
-  end
-
-  defp process_output(
-         sequence,
-         lengths,
-         timestamps?,
-         timestamp_begin_id,
-         time_precision,
-         tokenizer,
-         all_special_tokens,
-         acc
-       ) do
-    {chunk_length_seconds, context_left_seconds, context_right_seconds} =
-      lengths || {nil, 0.0, 0.0}
-
-    time_offset = acc.time_offset - context_left_seconds
+    time_offset = state.time_offset - context_left_seconds
 
     # We want to ignore timestamps in the right and left contexts,
     # because splitting on those would cause issues with merging
@@ -386,70 +501,86 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     # are not timestamps in the right context, we ignore the last
     # regular timestamp, otherwise we may not have enough tokens
     # to merge chunks properly.
+    #
+    # Note that we don't know upfront whether the given chunk is the
+    # last one (because we support input streaming), therefore we
+    # always assume a non-zero right context (if enabled). However,
+    # we keep track of the final end time in the right context in the
+    # state (right_context_end_time), so once the input finishes
+    # and we emit the last chunk, we can mark the correct end time.
 
     first_timestamp = timestamp_begin_id + context_left_seconds / time_precision
 
-    last_timestamp =
+    {last_timestamp, right_context_last_timestamp} =
       if context_right_seconds > 0 do
         right_context_start = chunk_length_seconds - context_right_seconds
 
         sequence
         |> Enum.reverse()
-        |> Enum.reduce_while(nil, fn token_id, last_timestamp ->
+        |> Enum.reduce_while({nil, nil}, fn token_id, {last_timestamp, right_context_end_time} ->
           if token_id >= timestamp_begin_id do
+            right_context_end_time = right_context_end_time || token_id
+
             if last_timestamp != nil and
                  (token_id - timestamp_begin_id) * time_precision < right_context_start do
-              {:halt, last_timestamp}
+              {:halt, {last_timestamp, right_context_end_time}}
             else
-              {:cont, token_id}
+              {:cont, {token_id, right_context_end_time}}
             end
           else
-            {:cont, last_timestamp}
+            {:cont, {last_timestamp, right_context_end_time}}
           end
         end)
+      else
+        {nil, nil}
       end
 
-    acc =
-      Enum.reduce(sequence, acc, fn token_id, acc ->
+    right_context_end_time =
+      if right_context_last_timestamp do
+        time_offset + (right_context_last_timestamp - timestamp_begin_id) * time_precision
+      end
+
+    state =
+      Enum.reduce(sequence, state, fn token_id, state ->
         if token_id >= timestamp_begin_id do
           time = (token_id - timestamp_begin_id) * time_precision + time_offset
           time = Float.round(time, 2)
 
           cond do
             last_timestamp && token_id >= last_timestamp ->
-              acc
+              state
 
             # If we are continuing previously open timestamp, ignore
             # timestamps within the left context
-            acc.previous_sequences != [] and token_id < first_timestamp ->
-              acc
+            state.previous_sequences != [] and token_id < first_timestamp ->
+              state
 
-            acc.chunk.start_timestamp_seconds == nil ->
-              put_in(acc.chunk.start_timestamp_seconds, time)
+            state.chunk.start_timestamp_seconds == nil ->
+              put_in(state.chunk.start_timestamp_seconds, time)
 
-            acc.chunk.start_timestamp_seconds == time ->
-              acc
+            state.chunk.start_timestamp_seconds == time ->
+              state
 
             true ->
-              acc = put_in(acc.chunk.end_timestamp_seconds, time)
+              state = put_in(state.chunk.end_timestamp_seconds, time)
 
-              acc
+              state
               |> finish_current_sequence()
-              |> finish_chunk(timestamps?, tokenizer)
+              |> finish_chunk(tokenizer, options)
           end
         else
           token = Bumblebee.Tokenizer.id_to_token(tokenizer, token_id)
 
           if token in all_special_tokens do
             # Skip special tokens
-            acc
+            state
           else
-            %{acc | current_sequence: [token_id | acc.current_sequence]}
+            %{state | current_sequence: [token_id | state.current_sequence]}
           end
         end
       end)
 
-    acc = finish_current_sequence(acc)
+    state = finish_current_sequence(state)
 
     time_offset =
       if chunk_length_seconds do
@@ -458,25 +589,25 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
         time_offset
       end
 
-    %{acc | time_offset: time_offset}
+    %{state | time_offset: time_offset, right_context_end_time: right_context_end_time}
   end
 
-  defp finish_current_sequence(%{current_sequence: []} = acc), do: acc
+  defp finish_current_sequence(%{current_sequence: []} = state), do: state
 
-  defp finish_current_sequence(acc) do
+  defp finish_current_sequence(state) do
     %{
-      acc
+      state
       | current_sequence: [],
-        previous_sequences: [Enum.reverse(acc.current_sequence) | acc.previous_sequences]
+        previous_sequences: [Enum.reverse(state.current_sequence) | state.previous_sequences]
     }
   end
 
-  defp finish_chunk(%{previous_sequences: []} = acc, _timestamps?, _tokenizer) do
-    %{acc | chunk: empty_chunk()}
+  defp finish_chunk(%{previous_sequences: []} = state, _tokenizer, _options) do
+    %{state | chunk: empty_chunk()}
   end
 
-  defp finish_chunk(acc, timestamps?, tokenizer) do
-    sequences = Enum.reverse(acc.previous_sequences)
+  defp finish_chunk(state, tokenizer, %{timestamps?: timestamps?}) do
+    sequences = Enum.reverse(state.previous_sequences)
 
     {token_ids, rest_token_ids} = merge_overlapping_sequences(sequences)
 
@@ -492,12 +623,24 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
       end
 
     text = Bumblebee.Tokenizer.decode(tokenizer, chunk_token_ids)
-    acc = put_in(acc.chunk.text, text)
+
+    state =
+      update_in(state.chunk, fn chunk ->
+        %{
+          chunk
+          | text: text,
+            # We ignore timestamps in right chunk context, however once
+            # we get to the last chunk, the right context is no longer
+            # applicable, so we use the final end timestamp from the
+            # last right context
+            end_timestamp_seconds: chunk.end_timestamp_seconds || state.right_context_end_time
+        }
+      end)
 
     %{
-      acc
+      state
       | previous_sequences: previous_sequences,
-        chunks: [acc.chunk | acc.chunks],
+        chunks: [state.chunk | state.chunks],
         chunk: empty_chunk()
     }
   end
@@ -578,46 +721,5 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
     rest = Nx.to_flat_list(left_sequence)
 
     {merged_sequence, rest}
-  end
-
-  defp ffmpeg_read_as_pcm(path, sampling_rate) do
-    channels = 1
-
-    format =
-      case System.endianness() do
-        :little -> "f32le"
-        :big -> "f32be"
-      end
-
-    cond do
-      System.find_executable("ffmpeg") == nil ->
-        {:error, "ffmpeg not found in PATH"}
-
-      not File.exists?(path) ->
-        {:error, "no file found at #{path}"}
-
-      true ->
-        System.cmd("ffmpeg", [
-          "-i",
-          path,
-          "-ac",
-          Integer.to_string(channels),
-          "-ar",
-          Integer.to_string(sampling_rate),
-          "-f",
-          format,
-          "-hide_banner",
-          "-loglevel",
-          "quiet",
-          "pipe:1"
-        ])
-        |> case do
-          {data, 0} ->
-            {:ok, Nx.from_binary(data, :f32, backend: Nx.BinaryBackend)}
-
-          {_, 1} ->
-            {:error, "ffmpeg failed to decode the given file"}
-        end
-    end
   end
 end

--- a/lib/bumblebee/shared.ex
+++ b/lib/bumblebee/shared.ex
@@ -217,7 +217,7 @@ defmodule Bumblebee.Shared do
   def validate_input_for_stream!(input) do
     if is_list(input) do
       raise ArgumentError,
-            "serving only accepts singular input when stream is enabled," <>
+            "this serving only accepts singular input when stream is enabled," <>
               " call the serving with each input in the batch separately"
     end
 

--- a/test/bumblebee/audio/speech_to_text_whisper_test.exs
+++ b/test/bumblebee/audio/speech_to_text_whisper_test.exs
@@ -7,11 +7,27 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
 
   @audio_dir Path.expand("../../fixtures/audio", __DIR__)
 
-  test "generates transcription" do
+  setup_all do
     {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
     {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
     {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
     {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    }
+  end
+
+  test "generates transcription", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
 
     serving =
       Bumblebee.Audio.speech_to_text_whisper(
@@ -41,11 +57,13 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
            }
   end
 
-  test "supports compilation" do
-    {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
-    {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+  test "supports compilation", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
 
     serving =
       Bumblebee.Audio.speech_to_text_whisper(
@@ -53,8 +71,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         featurizer,
         tokenizer,
         generation_config,
-        defn_options: [compiler: EXLA],
-        compile: [batch_size: 1]
+        defn_options: [compiler: EXLA]
       )
 
     audio =
@@ -76,11 +93,13 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
            }
   end
 
-  test "long-form transcription with chunking" do
-    {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
-    {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+  test "long-form transcription with chunking", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
 
     serving =
       Bumblebee.Audio.speech_to_text_whisper(
@@ -89,7 +108,8 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         tokenizer,
         generation_config,
         chunk_num_seconds: 30,
-        defn_options: [compiler: EXLA]
+        defn_options: [compiler: EXLA],
+        compile: [batch_size: 1]
       )
 
     audio =
@@ -115,11 +135,13 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
            }
   end
 
-  test "long-form transcription with timestamps" do
-    {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
-    {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+  test "long-form transcription with enumerable input", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
 
     serving =
       Bumblebee.Audio.speech_to_text_whisper(
@@ -129,6 +151,51 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         generation_config,
         chunk_num_seconds: 30,
         defn_options: [compiler: EXLA],
+        compile: [batch_size: 1]
+      )
+
+    # Audio in chunks of 1s, should give the same result as above
+    audio =
+      Path.join(@audio_dir, "librivox/46s_pcm_f32le_16000.bin")
+      |> File.read!()
+      |> binary_chunk_every(16000 * 4)
+      |> Enum.map(&Nx.from_binary(&1, :f32))
+
+    assert Nx.Serving.run(serving, audio) == %{
+             chunks: [
+               %{
+                 text:
+                   " An awakening from the book of Irish poetry part 1, read for LibriVox.org by Sonja. An awakening by Alice Pirlong. O spring will wake in the heart of me with the rapture of blown violets, when the green bud quickens on every tree to spring will wake in the heart of me, and queues of honey",
+                 start_timestamp_seconds: nil,
+                 end_timestamp_seconds: nil
+               },
+               %{
+                 text:
+                   " will reign on the lee, tangling the grasses in silver nets. Yes, spring will awaken the heart of me with the rapture of blown violets. End of an awakening, this recording is in the public domain.",
+                 start_timestamp_seconds: nil,
+                 end_timestamp_seconds: nil
+               }
+             ]
+           }
+  end
+
+  test "long-form transcription with timestamps", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
+
+    serving =
+      Bumblebee.Audio.speech_to_text_whisper(
+        model_info,
+        featurizer,
+        tokenizer,
+        generation_config,
+        chunk_num_seconds: 30,
+        defn_options: [compiler: EXLA],
+        compile: [batch_size: 1],
         timestamps: :segments
       )
 
@@ -182,11 +249,13 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
            }
   end
 
-  test "streaming without timestamps" do
-    {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
-    {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+  test "streaming without timestamps", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
 
     serving =
       Bumblebee.Audio.speech_to_text_whisper(
@@ -196,6 +265,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         generation_config,
         chunk_num_seconds: 30,
         defn_options: [compiler: EXLA],
+        compile: [batch_size: 1],
         stream: true
       )
 
@@ -222,11 +292,13 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
            ]
   end
 
-  test "streaming with timestamps" do
-    {:ok, model_info} = Bumblebee.load_model({:hf, "openai/whisper-tiny"})
-    {:ok, featurizer} = Bumblebee.load_featurizer({:hf, "openai/whisper-tiny"})
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "openai/whisper-tiny"})
-    {:ok, generation_config} = Bumblebee.load_generation_config({:hf, "openai/whisper-tiny"})
+  test "streaming with timestamps", ctx do
+    %{
+      model_info: model_info,
+      featurizer: featurizer,
+      tokenizer: tokenizer,
+      generation_config: generation_config
+    } = ctx
 
     serving =
       Bumblebee.Audio.speech_to_text_whisper(
@@ -236,6 +308,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
         generation_config,
         chunk_num_seconds: 30,
         defn_options: [compiler: EXLA],
+        compile: [batch_size: 1],
         timestamps: :segments,
         stream: true
       )
@@ -288,5 +361,20 @@ defmodule Bumblebee.Audio.SpeechToTextWhisperTest do
                end_timestamp_seconds: 40.72
              }
            ]
+  end
+
+  defp binary_chunk_every(binary, size), do: binary_chunk_every(binary, size, [])
+
+  defp binary_chunk_every(binary, size, acc) do
+    case binary do
+      <<chunk::binary-size(size), rest::binary>> ->
+        binary_chunk_every(rest, size, [chunk | acc])
+
+      <<>> ->
+        Enum.reverse(acc)
+
+      chunk ->
+        Enum.reverse([chunk | acc])
+    end
   end
 end


### PR DESCRIPTION
Closes #261.

This allows the Whisper serving to accept a stream of consecutive chunks. Importantly, this improves the `{:file, path}`, such that we read the file in chunks using ffmpeg, rather than loading it into memory all at once.

This PR drops support for a list if inputs, such as `Nx.Serving.batched_run(MyServing, [{:file, path1}, {:file2, path2}]`). This serving works on a higher level than usually, because a single chunked input is already multiple inputs to the model, so I think this is sane. Multiple inputs can be processed concurrently by calling `batched_run` from multiple processes.

I noticed a bug, specifically when streaming with timestamps and using a `batch_size`, we would ignore small segments after every batch.

---

@josevalim I went with the stream of consecutive chunks and handle accumulation + overlapping internally. I think it is preferable to keep the chunking details internal and I don't see a benefit of exposing it. If we shift accumulation to the user, they would basically need to do exactly that. For ffmpeg we would do that in bumblebee anyway, because accumulation is better than duplicating ffmpeg decoding work.