### PR TITLE
Update RoBERTa tokenizer in examples

### DIFF
--- a/notebooks/examples.livemd
+++ b/notebooks/examples.livemd
@@ -180,7 +180,7 @@ Another text-related task is question answering, where the objective is to retri
 
 ```elixir
 {:ok, roberta} = Bumblebee.load_model({:hf, "deepset/roberta-base-squad2"})
-{:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "roberta-FacebookAI/roberta-base"})
+{:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "FacebookAI/roberta-base"})
 
 serving = Bumblebee.Text.question_answering(roberta, tokenizer)
 


### PR DESCRIPTION
The tokenizer for roberta has been migrated from "roberta-FacebookAI/roberta-base" to "FacebookAI/roberta-base", causing the example to fail.

This commit updates the tokenizer path, thereby fixing the broken example.