### PR TITLE
Fixed broken link in LLMs and RAG livebook

### DIFF
--- a/notebooks/llms_rag.livemd
+++ b/notebooks/llms_rag.livemd
@@ -26,7 +26,7 @@ The first step is to download the text document, in this case we use an essay wr
 ```elixir
 %{body: text} =
   Req.get!(
-    "https://raw.githubusercontent.com/run-llama/llama_index/main/docs/examples/data/paul_graham/paul_graham_essay.txt"
+    "https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt"
   )
 
 IO.puts("Document length: #{String.length(text)}")


### PR DESCRIPTION
The essay in the example livebook has been moved to a new location.