### PR TITLE
Fix documentation typos

### DIFF
--- a/notebooks/fine_tuning.livemd
+++ b/notebooks/fine_tuning.livemd
@@ -16,7 +16,7 @@ Nx.default_backend(EXLA.Backend)
 
 ## Introduction
 
-Fine-tuning is the process of specializing the parameters in a pre-trained model to a specific task. Large-language models such as BERT train on a generic langauge-modeling task which makes them powerful at extracting features from text. Despite their power, you often still need to train them on a downstream task.
+Fine-tuning is the process of specializing the parameters in a pre-trained model to a specific task. Large-language models such as BERT train on a generic language-modeling task which makes them powerful at extracting features from text. Despite their power, you often still need to train them on a downstream task.
 
 This example demonstrates how to use Bumblebee and Axon to fine-tune a pre-trained Bert model to classify Yelp reviews into classes of 1-5 stars. This example is based on [Fine-tune a pretrained model](https://huggingface.co/docs/transformers/training) from Huggingface.
 

--- a/notebooks/llms.livemd
+++ b/notebooks/llms.livemd
@@ -13,7 +13,7 @@ Nx.global_default_backend({EXLA.Backend, client: :host})
 
 ## Introduction
 
-In this notebook we outline the general setup for running a Large Langauge Model (LLM).
+In this notebook we outline the general setup for running a Large Language Model (LLM).
 
 <!-- livebook:{"branch_parent_index":0} -->
 


### PR DESCRIPTION
Hello!

Fixes two typos in the Livebook examples. I've also ran `aspell` on all `.md` and `.livemd` files to check that there aren't more of those.