### PR TITLE
Add support for CLS token pooling in text embedding

### DIFF
--- a/lib/bumblebee/text.ex
+++ b/lib/bumblebee/text.ex
@@ -313,8 +313,9 @@ defmodule Bumblebee.Text do
       this option is ignored. Defaults to `:pooled_state`
 
     * `:output_pool` - pooling to apply on top of the model output, in case
-      it is not already a pooled embedding. Supported values: `:mean_pooling`.
-      By default no pooling is applied
+      it is not already a pooled embedding. Supported values: `:mean_pooling` or `cls_token_pooling`.
+      For `cls_token_pooling` we assume that the first token is the CLS token.
+      By default no pooling is applied.
 
     * `:embedding_processor` - a post-processing step to apply to the
       embedding. Supported values: `:l2_norm`. By default the output is

--- a/lib/bumblebee/text.ex
+++ b/lib/bumblebee/text.ex
@@ -313,9 +313,15 @@ defmodule Bumblebee.Text do
       this option is ignored. Defaults to `:pooled_state`
 
     * `:output_pool` - pooling to apply on top of the model output, in case
-      it is not already a pooled embedding. Supported values: `:mean_pooling` or `cls_token_pooling`.
-      For `cls_token_pooling` we assume that the first token is the CLS token.
-      By default no pooling is applied.
+      it is not already a pooled embedding. Supported values:
+
+        * `:mean_pooling` - performs a mean across all tokens
+        
+        * `cls_token_pooling` - takes the embedding for the special CLS token.
+          Note that we currently assume that the CLS token is the first token
+          in the sequence
+
+      By default no pooling is applied
 
     * `:embedding_processor` - a post-processing step to apply to the
       embedding. Supported values: `:l2_norm`. By default the output is

--- a/lib/bumblebee/text/text_embedding.ex
+++ b/lib/bumblebee/text/text_embedding.ex
@@ -65,8 +65,8 @@ defmodule Bumblebee.Text.TextEmbedding do
             case Nx.rank(output) do
               3 ->
                 # Assuming CLS token is always at the first position
-                Nx.slice_along_axis(output, 0, 1, axis: 1) |> Nx.squeeze(axes: [1])
-
+                Nx.take(output, 0, axis: 1)
+                
               rank ->
                 raise ArgumentError,
                       "expected the output tensor to have rank 3 to apply :cls pooling, got: #{rank}." <>

--- a/lib/bumblebee/text/text_embedding.ex
+++ b/lib/bumblebee/text/text_embedding.ex
@@ -66,7 +66,7 @@ defmodule Bumblebee.Text.TextEmbedding do
               3 ->
                 # Assuming CLS token is always at the first position
                 Nx.take(output, 0, axis: 1)
-                
+
               rank ->
                 raise ArgumentError,
                       "expected the output tensor to have rank 3 to apply :cls pooling, got: #{rank}." <>

--- a/lib/bumblebee/text/text_embedding.ex
+++ b/lib/bumblebee/text/text_embedding.ex
@@ -61,6 +61,18 @@ defmodule Bumblebee.Text.TextEmbedding do
           nil ->
             output
 
+          :cls_token_pooling ->
+            case Nx.rank(output) do
+              3 ->
+                # Assuming CLS token is always at the first position
+                Nx.slice_along_axis(output, 0, 1, axis: 1) |> Nx.squeeze(axes: [1])
+
+              rank ->
+                raise ArgumentError,
+                      "expected the output tensor to have rank 3 to apply :cls pooling, got: #{rank}." <>
+                        " You should either disable pooling or pick a different output using :output_attribute"
+            end
+
           :mean_pooling ->
             case Nx.rank(output) do
               3 ->
@@ -81,7 +93,7 @@ defmodule Bumblebee.Text.TextEmbedding do
 
           other ->
             raise ArgumentError,
-                  "expected :output_pool to be one of nil or :mean_pooling, got: #{inspect(other)}"
+                  "expected :output_pool to be one of :cls_token_pooling, :mean_pooling or nil, got: #{inspect(other)}"
         end
 
       output =

--- a/lib/bumblebee/text/text_embedding.ex
+++ b/lib/bumblebee/text/text_embedding.ex
@@ -56,34 +56,21 @@ defmodule Bumblebee.Text.TextEmbedding do
             output
         end
 
+      if output_pool != nil and Nx.rank(output) != 3 do
+        raise ArgumentError,
+              "expected the output tensor to have rank 3 to apply :output_pool, got: #{Nx.rank(output)}." <>
+                " You should either disable pooling or pick a different output using :output_attribute"
+      end
+
       output =
         case output_pool do
           nil ->
             output
 
           :cls_token_pooling ->
-            case Nx.rank(output) do
-              3 ->
-                # Assuming CLS token is always at the first position
-                Nx.take(output, 0, axis: 1)
-
-              rank ->
-                raise ArgumentError,
-                      "expected the output tensor to have rank 3 to apply :cls pooling, got: #{rank}." <>
-                        " You should either disable pooling or pick a different output using :output_attribute"
-            end
+            Nx.take(output, 0, axis: 1)
 
           :mean_pooling ->
-            case Nx.rank(output) do
-              3 ->
-                :ok
-
-              rank ->
-                raise ArgumentError,
-                      "expected the output tensor to have rank 3 to apply :output_pool, got: #{rank}." <>
-                        " You should either disable pooling or pick a different output using :output_attribute"
-            end
-
             input_mask_expanded = Nx.new_axis(inputs["attention_mask"], -1)
 
             output

--- a/test/bumblebee/text/text_embedding_test.exs
+++ b/test/bumblebee/text/text_embedding_test.exs
@@ -100,4 +100,19 @@ defmodule Bumblebee.Text.TextEmbeddingTest do
 
     assert_equal(embedding1, embedding2)
   end
+
+  test "cls token pooling" do
+    {:ok, model_info} = Bumblebee.load_model({:hf, "intfloat/e5-small-v2"})
+    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "intfloat/e5-small-v2"})
+
+    serving =
+      Bumblebee.Text.text_embedding(model_info, tokenizer,
+        output_attribute: :hidden_state,
+        output_pool: :cls_token_pooling,
+        embedding_processor: :l2_norm
+      )
+
+      # Nx.Serving.run(serving, "A long text to test the embeddings")
+      # TBD: tests 
+  end
 end

--- a/test/bumblebee/text/text_embedding_test.exs
+++ b/test/bumblebee/text/text_embedding_test.exs
@@ -100,19 +100,4 @@ defmodule Bumblebee.Text.TextEmbeddingTest do
 
     assert_equal(embedding1, embedding2)
   end
-
-  test "cls token pooling" do
-    {:ok, model_info} = Bumblebee.load_model({:hf, "intfloat/e5-small-v2"})
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "intfloat/e5-small-v2"})
-
-    serving =
-      Bumblebee.Text.text_embedding(model_info, tokenizer,
-        output_attribute: :hidden_state,
-        output_pool: :cls_token_pooling,
-        embedding_processor: :l2_norm
-      )
-
-      # Nx.Serving.run(serving, "A long text to test the embeddings")
-      # TBD: tests 
-  end
 end


### PR DESCRIPTION
This PR adding support for token pooling for models like [BGE-M3](https://huggingface.co/BAAI/bge-m3). 

```elixir
model_id = "BAAI/bge-m3"
{:ok, model_info} = Bumblebee.load_model({:hf,  model_id})
{:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, model_id})
serving =
      Bumblebee.Text.text_embedding(model_info, tokenizer,
        output_attribute: :hidden_state,
        output_pool: :cls_token_pooling,
        embedding_processor: :l2_norm
      )

Nx.Serving.run(serving, "A long text to test the embeddings")
%{
  embedding: #Nx.Tensor<
    f32[1024]
    [-0.04741977900266647, -0.02085975557565689, -0.028225498273968697, 0.02299957536160946, -0.011559668928384781, -0.07012897729873657, 0.03340381383895874, -0.01976216770708561, -0.03233117237687111, 0.006122056394815445, -0.010670339688658714, -0.013755269348621368, 0.022028403356671333, 0.01282929815351963, -0.011613521724939346, -0.03025030717253685, -0.0033455477096140385, -0.020186245441436768, -0.003963503520935774, -0.030614720657467842, -0.04809923842549324, -0.04979144409298897, -0.005613392218947411, 0.03222518414258957, 0.008074230514466763, 0.04548024386167526, -0.04274187982082367, -8.126439643092453e-4, 0.006089380942285061, -0.013495399616658688, 0.014120037667453289, 6.303095142357051e-4, 0.01951751671731472, -0.021895553916692734, 0.029148466885089874, -0.03433115407824516, 0.02577170729637146, 0.0065758670680224895, -0.023974351584911346, -0.032213930040597916, 6.08053058385849e-4, 0.011225073598325253, 0.00818843673914671, -0.044494032859802246, 0.009402443654835224, -0.02151455357670784, 0.02456141822040081, -0.04354599490761757, -0.03464091941714287, ...]
```
Bellow are the results from the python implementation (i am using only the "dense" output and not the sparse one) 
```python
In [16]: from FlagEmbedding import BGEM3FlagModel
In [17]: model = BGEM3FlagModel('BAAI/bge-m3', use_fp16=True)
In [18]: sentences_1 = "A long text to test the embeddings"

In [19]: embeddings_1 = model.encode(sentences_1, batch_size=12, max_length=8192 )['dense_vecs']

In [20]: embeddings_1
Out[20]:
array([-0.0474  , -0.02089 , -0.0282  , ..., -0.002155, -0.02812 ,
        0.05673 ], dtype=float16)
```
I believe the small differences are because of different implementation of floating point between python <> elixir. 
