### PR TITLE
Fix typo in load_tokenizer's ArgumentError

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -911,7 +911,7 @@ defmodule Bumblebee do
                   type
 
                 {:error, error} ->
-                  raise ArgumentError, "#{error}, please specify the :module option"
+                  raise ArgumentError, "#{error}, please specify the :type option"
               end
 
           tokenizer_config_result =


### PR DESCRIPTION
A prior commit 8b52612 removed the concept of tokenizer modules and introduced tokenizer types. As part of the change, the sole expected option for the `load_tokenizer` function was changed from `:module` to `:type`.

Unfortunately the commit missed out on changing the error message, which could cause slight confusion amongst devs that use `load_tokenizer` when upgrading bumblebee from pre-v0.5.0.