### PR TITLE
Update link to Mistral docs

### DIFF
--- a/notebooks/llms_rag.livemd
+++ b/notebooks/llms_rag.livemd
@@ -357,4 +357,4 @@ And here we have our answer!
 
 <!-- livebook:{"break_markdown":true} -->
 
-For additional context you can also visit the [Mistral docs](https://docs.mistral.ai/guides/basic-RAG) that go through a similar example.
+For additional context you can also visit the [Mistral docs](https://docs.mistral.ai/guides/rag/) that go through a similar example.


### PR DESCRIPTION
Hi, I've noticed that the link to the Mistral documentation was returning a 404, so I am adjusting here to the the new one.