### PR TITLE
feat: Add ColBERT support

### DIFF
--- a/lib/bumblebee.ex
+++ b/lib/bumblebee.ex
@@ -101,6 +101,7 @@ defmodule Bumblebee do
     "BertForTokenClassification" => {Bumblebee.Text.Bert, :for_token_classification},
     "BertLMHeadModel" => {Bumblebee.Text.Bert, :for_causal_language_modeling},
     "BertModel" => {Bumblebee.Text.Bert, :base},
+    "HF_ColBERT" => {Bumblebee.Text.Bert, :for_colbert},
     "BlenderbotForConditionalGeneration" =>
       {Bumblebee.Text.Blenderbot, :for_conditional_generation},
     "BlenderbotModel" => {Bumblebee.Text.Blenderbot, :base},


### PR DESCRIPTION
This adds support for ColBERT models like `colbert-ir/colbertv2.0`.

ColBERT is basically BERT with a linear projection layer on top that maps the hidden state from 768 to 128 dimensions (configurable via `embedding_size`). It's used for late-interaction retrieval.

I went with adding a `:for_colbert` architecture to the existing BERT module since it's just one extra layer. Not sure if you'd prefer a separate model instead, let me know.

Changes:
- Added `embedding_size` option to BERT spec (defaults to 128)
- Added `:for_colbert` architecture with the linear projection head
- Added `HF_ColBERT` to the class mapping
- Added a test verified against Python transformers (tagged as slow since there's no tiny model)