### PR TITLE
  feat: Add token metrics and OpenAI-compatible response format to text generation

### DIFF
--- a/lib/bumblebee/text/translation.ex
+++ b/lib/bumblebee/text/translation.ex
@@ -121,9 +121,13 @@ defmodule Bumblebee.Text.Translation do
       batch_key = Shared.sequence_batch_key_for_inputs(inputs, sequence_length)
       batch = [inputs] |> Nx.Batch.concatenate() |> Nx.Batch.key(batch_key)
 
-      {batch, {multi?, input_length, input_padded_length}}
+      # Translation doesn't support timing, so start_time is nil
+      {batch, {multi?, input_length, input_padded_length, nil}}
     end)
-    |> Text.TextGeneration.add_postprocessing(opts[:stream], opts[:stream_done], tokenizer)
+    |> Text.TextGeneration.add_postprocessing(tokenizer,
+      stream: opts[:stream],
+      stream_done: opts[:stream_done]
+    )
   end
 
   defp validate_input(


### PR DESCRIPTION
## Summary

  This PR adds timing metrics and opt-in OpenAI-compatible response formats to Bumblebee's text generation serving, making it easier to integrate with
  existing OpenAI-compatible tooling and monitor generation performance. 
  This will help bumblebee to integrated easier with other libs without writing custom middlewares . 

  ## New Options

  Three new options for `Bumblebee.Text.generation/4`:

  - **`:include_timing`** - When `true`, includes performance metrics in results
  - **`:output_format`** - Supports `:bumblebee` (default), `:openai`, and `:openai_chat`
  - **`:model_name`** - Model identifier for OpenAI format responses

  ## Features

  ### Timing Metrics
  When `include_timing: true`:
  - `generation_time_us` - Total generation time in microseconds
  - `tokens_per_second` - Generation throughput
  - `time_to_first_token_us` - Time to first token (streaming only)

  ### Finish Reason Tracking
  Tracks why generation stopped:
  - `"stop"` - EOS token reached
  - `"length"` - Max length reached

  ### OpenAI-Compatible Formats

  **Text Completions** (`:openai`):
  ```elixir
  %{
    id: "cmpl-...",
    object: "text_completion",
    model: "gpt2",
    choices: [%{index: 0, text: "...", finish_reason: "stop"}],
    usage: %{prompt_tokens: 5, completion_tokens: 20, total_tokens: 25}
  }

  Chat Completions (:openai_chat):
  %{
    id: "chatcmpl-...",
    object: "chat.completion",
    model: "gpt2",
    choices: [%{index: 0, message: %{role: "assistant", content: "..."}, finish_reason: "stop"}],
    usage: %{prompt_tokens: 5, completion_tokens: 20, total_tokens: 25}
  }

  Both formats also support streaming with proper chunk formatting.

  Backward Compatibility

  All changes are opt-in with sensible defaults:
  - include_timing: false
  - output_format: :bumblebee

  Existing code works unchanged.

  Test Plan

  - All existing tests pass
  - Added tests for timing metrics (streaming and non-streaming)
  - Added tests for OpenAI format output
  - Added tests for OpenAI chat format output
  - Added tests for OpenAI streaming formats
  - Manually tested with Qwen3-0.6B model