### PR TITLE
fix: update URL to fetch Paul Graham essay

### DIFF
--- a/notebooks/llms_rag.livemd
+++ b/notebooks/llms_rag.livemd
@@ -26,7 +26,7 @@ The first step is to download the text document, in this case we use an essay wr
 ```elixir
 %{body: text} =
   Req.get!(
-    "https://raw.githubusercontent.com/run-llama/llama_index/main/docs/docs/examples/data/paul_graham/paul_graham_essay.txt"
+    "https://raw.githubusercontent.com/run-llama/llama_index/refs/heads/main/docs/examples/data/paul_graham/paul_graham_essay.txt"
   )
 
 IO.puts("Document length: #{String.length(text)}")


### PR DESCRIPTION
The original URL is now a 404, replacing it with the new location.