### PR TITLE
Fix crash when creating tensor from empty buffer in whisper

### DIFF
--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -318,8 +318,11 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
         buffer = buffer ++ [chunk]
         full_chunks([], {buffer, buffer_size}, chunk_length, step)
       end,
-      fn {buffer, buffer_size} ->
-        {[Nx.concatenate(buffer)], {buffer, buffer_size}}
+      fn
+        {[], buffer_size} ->
+          {[], {[], buffer_size}}
+        {buffer, buffer_size} ->
+          {[Nx.concatenate(buffer)], {buffer, buffer_size}}
       end,
       fn _ -> :ok end
     )

--- a/lib/bumblebee/audio/speech_to_text_whisper.ex
+++ b/lib/bumblebee/audio/speech_to_text_whisper.ex
@@ -321,6 +321,7 @@ defmodule Bumblebee.Audio.SpeechToTextWhisper do
       fn
         {[], buffer_size} ->
           {[], {[], buffer_size}}
+
         {buffer, buffer_size} ->
           {[Nx.concatenate(buffer)], {buffer, buffer_size}}
       end,


### PR DESCRIPTION
Hi, I've run into an issue when my audio tensor is exactly aligned with the chunk length for the Whisper serving, here's an MRE script:

```
Mix.install(
  [
    {:bumblebee, "~> 0.6"},
    {:exla, "~> 0.10"}
  ],
  config: [nx: [default_backend: EXLA.Backend]]
)

hf_repo = "openai/whisper-tiny"

{:ok, whisper} = Bumblebee.load_model({:hf, hf_repo})
{:ok, featurizer} = Bumblebee.load_featurizer({:hf, hf_repo})
{:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, hf_repo})
{:ok, generation_config} = Bumblebee.load_generation_config({:hf, hf_repo})

serving =
  Bumblebee.Audio.speech_to_text_whisper(
    whisper,
    featurizer,
    tokenizer,
    generation_config,
    stream: false,
    chunk_num_seconds: 10,
    context_num_seconds: 0,
    defn_options: [compiler: EXLA]
  )

sample_rate = 16_000
chunk_num_seconds = 10
audio = Nx.broadcast(0.0, {chunk_num_seconds * sample_rate})

serving
|> Nx.Serving.run(audio)
|> Enum.to_list()
```

Output (same with e.g. `chunk_num_seconds = 20`):
```
** (ArgumentError) no tensors were given to concatenate
    (nx 0.10.0) lib/nx.ex:14684: Nx.concatenate/2
    (bumblebee 0.6.3) lib/bumblebee/audio/speech_to_text_whisper.ex:320: anonymous fn/1 in Bumblebee.Audio.SpeechToTextWhisper.chunk_input/4
    (elixir 1.19.5) lib/stream.ex:982: Stream.do_transform/5
    (elixir 1.19.5) lib/stream.ex:1773: Enumerable.Stream.do_each/4
    (elixir 1.19.5) lib/enum.ex:4570: Enum.map_reduce/3
    (nx 0.10.0) lib/nx/serving.ex:697: Nx.Serving.run/2
    examples/mre.exs:33: (file)
```

I've only run into this issue when disabling overlapping with `context_num_seconds: 0`, since it would be hard to align the windows length with the default value of 1/6th of the chunk length.